### PR TITLE
feat: add background job to refresh stream statuses

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import {
   getStream,
   listStreams,
   initSoroban,
+  refreshStreamStatuses,
   syncStreams,
   StreamInput,
 } from "./services/streamStore";
@@ -154,12 +155,18 @@ app.get("/api/open-issues", (_req: Request, res: Response) => {
   res.json({ data: openIssues });
 });
 
+const STATUS_REFRESH_INTERVAL_MS = 60 * 1000;
+
 async function startServer() {
   await initSoroban();
   await syncStreams();
 
   app.listen(port, () => {
     console.log(`StellarStream API listening on http://localhost:${port}`);
+    setInterval(() => {
+      const n = refreshStreamStatuses();
+      console.log(`Status refresh job run, ${n} stream(s) updated.`);
+    }, STATUS_REFRESH_INTERVAL_MS);
   });
 }
 


### PR DESCRIPTION
## Description

Adds a lightweight background job that periodically refreshes stream statuses so streams are marked completed when their end time is reached, without relying only on request-time calculations.

closes #19 

## Changes

- **StreamRecord**: Added optional `completedAt?: number`. Set by the background job when a stream’s end time has passed.
- **Status logic**: `computeStatus()` treats streams with `completedAt` as `"completed"`; existing time-based logic is unchanged for list/get.
- **`refreshStreamStatuses()`**: New function in `streamStore` that scans all streams and, for any that are not canceled and not already completed and whose end time has passed, sets `completedAt` to the current time. Returns the number of streams updated.
- **Background job**: After the server starts, a `setInterval` runs every 60 seconds, calls `refreshStreamStatuses()`, and logs: `Status refresh job run, N stream(s) updated.`

## Acceptance criteria

- [x] Completed status updates even without manual user actions (job runs every 60s).
- [x] Job runs safely and does not duplicate state transitions (only sets `completedAt` when it is currently undefined).
- [x] No API behavior regressions: list and get still use `calculateProgress(stream)`; response shape and status derivation are unchanged.

## Testing

- Backend builds successfully.
- List/get responses unchanged; `progress.status` remains derived from existing fields plus `completedAt`.