### PR TITLE
feature: improve ui validation

### DIFF
--- a/frontend/src/components/CreateStreamForm.tsx
+++ b/frontend/src/components/CreateStreamForm.tsx
@@ -1,101 +1,361 @@
 import { FormEvent, useState } from "react";
 import { CreateStreamPayload } from "../types/stream";
+import {
+  FieldErrors,
+  FormValues,
+  isStellarAccount,
+  validateForm,
+  isFormValid,
+} from "../hooks/useFormValidation";
 
 interface CreateStreamFormProps {
   onCreate: (payload: CreateStreamPayload) => Promise<void>;
+  apiError?: string | null;
 }
 
-export function CreateStreamForm({ onCreate }: CreateStreamFormProps) {
-  const [sender, setSender] = useState("GDSENDEREXAMPLEDEMO0000000000000000000000000000000000");
-  const [recipient, setRecipient] = useState("GDRECIPIENTDEMO000000000000000000000000000000000000");
-  const [assetCode, setAssetCode] = useState("USDC");
-  const [totalAmount, setTotalAmount] = useState("150");
-  const [durationHours, setDurationHours] = useState("24");
-  const [startInMinutes, setStartInMinutes] = useState("0");
+// Derive a user-friendly hint from a raw API error message.
+function humaniseApiError(raw: string): { title: string; hint: string } {
+  const lower = raw.toLowerCase();
+
+  if (lower.includes("sender") || lower.includes("recipient")) {
+    return {
+      title: "Invalid account ID",
+      hint: 'Double-check that both account IDs start with "G" and are exactly 56 characters. You can copy them from Stellar Laboratory.',
+    };
+  }
+  if (lower.includes("asset") || lower.includes("assetcode")) {
+    return {
+      title: "Invalid asset code",
+      hint: 'Asset codes must be 1–12 alphanumeric characters. Common examples: USDC, XLM, AQUA.',
+    };
+  }
+  if (lower.includes("amount")) {
+    return {
+      title: "Invalid amount",
+      hint: "The total amount must be a positive number. Check that you haven't entered zero or a negative value.",
+    };
+  }
+  if (lower.includes("duration") || lower.includes("seconds")) {
+    return {
+      title: "Invalid duration",
+      hint: "Stream duration must be at least 1 hour (3 600 seconds). Increase the duration and try again.",
+    };
+  }
+  if (lower.includes("not found")) {
+    return {
+      title: "Stream not found",
+      hint: "This stream may have already been cancelled or never existed. Refresh the page to see the latest state.",
+    };
+  }
+  if (lower.includes("network") || lower.includes("fetch")) {
+    return {
+      title: "Network error",
+      hint: "Could not reach the StellarStream API. Ensure the backend is running and your network connection is stable.",
+    };
+  }
+
+  return {
+    title: "Something went wrong",
+    hint: raw,
+  };
+}
+
+// StellarAccountStatus: live character-count + format hint shown under account fields.
+function AccountHint({ value }: { value: string }) {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+
+  const len = trimmed.length;
+  const valid = isStellarAccount(trimmed);
+
+  if (valid) {
+    return (
+      <span className="field-hint field-hint--ok" aria-live="polite">
+        ✓ Valid Stellar account ({len}/56)
+      </span>
+    );
+  }
+
+  if (!trimmed.startsWith("G")) {
+    return (
+      <span className="field-hint field-hint--warn" aria-live="polite">
+        Account IDs must start with the letter G ({len}/56 chars)
+      </span>
+    );
+  }
+
+  return (
+    <span className="field-hint field-hint--warn" aria-live="polite">
+      {len < 56 ? `${56 - len} more character${56 - len !== 1 ? "s" : ""} needed` : "Too long — must be exactly 56 characters"}{" "}
+      ({len}/56)
+    </span>
+  );
+}
+
+const INITIAL_VALUES: FormValues = {
+  sender: "",
+  recipient: "",
+  assetCode: "USDC",
+  totalAmount: "150",
+  durationHours: "24",
+  startInMinutes: "0",
+};
+
+export function CreateStreamForm({ onCreate, apiError }: CreateStreamFormProps) {
+  const [values, setValues] = useState<FormValues>(INITIAL_VALUES);
+  const [touched, setTouched] = useState<Partial<Record<keyof FormValues, boolean>>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+
+  // Run validation on current values
+  const errors: FieldErrors = validateForm(values);
+  const formValid = isFormValid(errors);
+
+  function set(field: keyof FormValues) {
+    return (e: React.ChangeEvent<HTMLInputElement>) => {
+      setValues((prev) => ({ ...prev, [field]: e.target.value }));
+    };
+  }
+
+  function blur(field: keyof FormValues) {
+    return () => setTouched((prev) => ({ ...prev, [field]: true }));
+  }
+
+  // Show an error for a field only after the user has touched it (or tried to submit)
+  function fieldError(field: keyof FormValues): string | undefined {
+    return (touched[field] || submitAttempted) ? errors[field] : undefined;
+  }
 
   async function handleSubmit(event: FormEvent) {
     event.preventDefault();
-    setIsSubmitting(true);
+    setSubmitAttempted(true);
 
+    if (!formValid) return;
+
+    setIsSubmitting(true);
     try {
       const now = Math.floor(Date.now() / 1000);
-      const offsetMinutes = Number(startInMinutes);
+      const offsetMinutes = Number(values.startInMinutes);
       const startAt = offsetMinutes > 0 ? now + Math.floor(offsetMinutes * 60) : undefined;
 
       await onCreate({
-        sender: sender.trim(),
-        recipient: recipient.trim(),
-        assetCode: assetCode.trim().toUpperCase(),
-        totalAmount: Number(totalAmount),
-        durationSeconds: Math.floor(Number(durationHours) * 3600),
+        sender: values.sender.trim(),
+        recipient: values.recipient.trim(),
+        assetCode: values.assetCode.trim().toUpperCase(),
+        totalAmount: Number(values.totalAmount),
+        durationSeconds: Math.floor(Number(values.durationHours) * 3600),
         startAt,
       });
+
+      // Reset on success
+      setValues(INITIAL_VALUES);
+      setTouched({});
+      setSubmitAttempted(false);
     } finally {
       setIsSubmitting(false);
     }
   }
 
+  const parsedApiError = apiError ? humaniseApiError(apiError) : null;
+
   return (
-    <form className="card form-grid" onSubmit={handleSubmit}>
+    <form className="card form-grid" onSubmit={handleSubmit} noValidate>
       <h2>Create Stream</h2>
 
-      <label>
-        Sender Account
-        <input value={sender} onChange={(e) => setSender(e.target.value)} required />
-      </label>
+      {/* API error banner — only shown for API-level errors */}
+      {parsedApiError && (
+        <div className="api-error-box" role="alert" aria-live="assertive">
+          <div className="api-error-box__title">
+            <span className="api-error-box__icon" aria-hidden>⚠</span>
+            {parsedApiError.title}
+          </div>
+          <div className="api-error-box__hint">{parsedApiError.hint}</div>
+        </div>
+      )}
 
-      <label>
-        Recipient Account
-        <input value={recipient} onChange={(e) => setRecipient(e.target.value)} required />
-      </label>
+      {/* Sender */}
+      <div className={`field-group${fieldError("sender") ? " field-group--error" : ""}`}>
+        <label htmlFor="stream-sender">
+          Sender Account
+          <span className="field-required" aria-hidden> *</span>
+        </label>
+        <input
+          id="stream-sender"
+          type="text"
+          value={values.sender}
+          onChange={set("sender")}
+          onBlur={blur("sender")}
+          placeholder="G…  (56-character Stellar public key)"
+          aria-describedby={fieldError("sender") ? "sender-error" : "sender-hint"}
+          aria-invalid={!!fieldError("sender")}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <AccountHint value={values.sender} />
+        {fieldError("sender") && (
+          <span id="sender-error" className="field-error" role="alert">
+            {fieldError("sender")}
+          </span>
+        )}
+      </div>
+
+      {/* Recipient */}
+      <div className={`field-group${fieldError("recipient") ? " field-group--error" : ""}`}>
+        <label htmlFor="stream-recipient">
+          Recipient Account
+          <span className="field-required" aria-hidden> *</span>
+        </label>
+        <input
+          id="stream-recipient"
+          type="text"
+          value={values.recipient}
+          onChange={set("recipient")}
+          onBlur={blur("recipient")}
+          placeholder="G…  (56-character Stellar public key)"
+          aria-describedby={fieldError("recipient") ? "recipient-error" : "recipient-hint"}
+          aria-invalid={!!fieldError("recipient")}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <AccountHint value={values.recipient} />
+        {fieldError("recipient") && (
+          <span id="recipient-error" className="field-error" role="alert">
+            {fieldError("recipient")}
+          </span>
+        )}
+      </div>
 
       <div className="row">
-        <label>
-          Asset
-          <input value={assetCode} onChange={(e) => setAssetCode(e.target.value)} required />
-        </label>
-        <label>
-          Total Amount
+        {/* Asset Code */}
+        <div className={`field-group${fieldError("assetCode") ? " field-group--error" : ""}`}>
+          <label htmlFor="stream-asset">
+            Asset Code
+            <span className="field-required" aria-hidden> *</span>
+          </label>
           <input
+            id="stream-asset"
+            type="text"
+            value={values.assetCode}
+            onChange={set("assetCode")}
+            onBlur={blur("assetCode")}
+            placeholder="USDC"
+            maxLength={12}
+            aria-describedby={fieldError("assetCode") ? "asset-error" : undefined}
+            aria-invalid={!!fieldError("assetCode")}
+          />
+          {fieldError("assetCode") && (
+            <span id="asset-error" className="field-error" role="alert">
+              {fieldError("assetCode")}
+            </span>
+          )}
+        </div>
+
+        {/* Total Amount */}
+        <div className={`field-group${fieldError("totalAmount") ? " field-group--error" : ""}`}>
+          <label htmlFor="stream-amount">
+            Total Amount
+            <span className="field-required" aria-hidden> *</span>
+          </label>
+          <input
+            id="stream-amount"
             type="number"
             min="0.000001"
             step="0.000001"
-            value={totalAmount}
-            onChange={(e) => setTotalAmount(e.target.value)}
-            required
+            value={values.totalAmount}
+            onChange={set("totalAmount")}
+            onBlur={blur("totalAmount")}
+            onKeyDown={(e) => {
+              // Block 'e', 'E', '+' which browsers allow in type=number
+              if (["e", "E", "+"].includes(e.key)) e.preventDefault();
+            }}
+            aria-describedby={fieldError("totalAmount") ? "amount-error" : undefined}
+            aria-invalid={!!fieldError("totalAmount")}
           />
-        </label>
+          {fieldError("totalAmount") && (
+            <span id="amount-error" className="field-error" role="alert">
+              {fieldError("totalAmount")}
+            </span>
+          )}
+        </div>
       </div>
 
       <div className="row">
-        <label>
-          Duration (hours)
+        {/* Duration */}
+        <div className={`field-group${fieldError("durationHours") ? " field-group--error" : ""}`}>
+          <label htmlFor="stream-duration">
+            Duration (hours)
+            <span className="field-required" aria-hidden> *</span>
+          </label>
           <input
+            id="stream-duration"
             type="number"
             min="1"
             step="1"
-            value={durationHours}
-            onChange={(e) => setDurationHours(e.target.value)}
-            required
+            value={values.durationHours}
+            onChange={set("durationHours")}
+            onBlur={blur("durationHours")}
+            onKeyDown={(e) => {
+              if (["e", "E", "+", "-", "."].includes(e.key)) e.preventDefault();
+            }}
+            aria-describedby={fieldError("durationHours") ? "duration-error" : undefined}
+            aria-invalid={!!fieldError("durationHours")}
           />
-        </label>
-        <label>
-          Start In (minutes)
+          {fieldError("durationHours") && (
+            <span id="duration-error" className="field-error" role="alert">
+              {fieldError("durationHours")}
+            </span>
+          )}
+        </div>
+
+        {/* Start In */}
+        <div className={`field-group${fieldError("startInMinutes") ? " field-group--error" : ""}`}>
+          <label htmlFor="stream-start">
+            Start In (minutes)
+            <span className="field-required" aria-hidden> *</span>
+          </label>
           <input
+            id="stream-start"
             type="number"
             min="0"
             step="1"
-            value={startInMinutes}
-            onChange={(e) => setStartInMinutes(e.target.value)}
-            required
+            value={values.startInMinutes}
+            onChange={set("startInMinutes")}
+            onBlur={blur("startInMinutes")}
+            onKeyDown={(e) => {
+              if (["e", "E", "+", "-", "."].includes(e.key)) e.preventDefault();
+            }}
+            aria-describedby={
+              fieldError("startInMinutes") ? "start-error" : "start-hint"
+            }
+            aria-invalid={!!fieldError("startInMinutes")}
           />
-        </label>
+          <span id="start-hint" className="field-hint">
+            Enter 0 to start immediately
+          </span>
+          {fieldError("startInMinutes") && (
+            <span id="start-error" className="field-error" role="alert">
+              {fieldError("startInMinutes")}
+            </span>
+          )}
+        </div>
       </div>
 
-      <button className="btn-primary" type="submit" disabled={isSubmitting}>
-        {isSubmitting ? "Creating..." : "Create Stream"}
+      {/* Submit */}
+      <button
+        className="btn-primary"
+        type="submit"
+        disabled={isSubmitting || (submitAttempted && !formValid)}
+        aria-busy={isSubmitting}
+      >
+        {isSubmitting ? "Creating…" : "Create Stream"}
       </button>
+
+      {/* Summary validation notice shown after first submit attempt */}
+      {submitAttempted && !formValid && (
+        <p className="form-summary-error" role="alert">
+          Please fix the errors above before submitting.
+        </p>
+      )}
     </form>
   );
 }

--- a/frontend/src/hooks/useFormValidation.ts
+++ b/frontend/src/hooks/useFormValidation.ts
@@ -1,0 +1,102 @@
+/**
+ * Stellar account IDs are base32-encoded Ed25519 public keys.
+ * A valid public key starts with 'G', is exactly 56 characters long,
+ * and uses the Stellar base32 alphabet (A-Z, 2-7).
+ */
+export const STELLAR_ACCOUNT_REGEX = /^G[A-Z2-7]{55}$/;
+
+export function isStellarAccount(value: string): boolean {
+  return STELLAR_ACCOUNT_REGEX.test(value.trim());
+}
+
+/** Asset codes: 1-12 alphanumeric chars per SEP-0001 / Stellar docs */
+export const ASSET_CODE_REGEX = /^[A-Za-z0-9]{1,12}$/;
+
+export interface FieldErrors {
+  sender?: string;
+  recipient?: string;
+  assetCode?: string;
+  totalAmount?: string;
+  durationHours?: string;
+  startInMinutes?: string;
+}
+
+export interface FormValues {
+  sender: string;
+  recipient: string;
+  assetCode: string;
+  totalAmount: string;
+  durationHours: string;
+  startInMinutes: string;
+}
+
+export function validateForm(values: FormValues): FieldErrors {
+  const errors: FieldErrors = {};
+
+  // --- Sender ---
+  const senderTrimmed = values.sender.trim();
+  if (!senderTrimmed) {
+    errors.sender = "Sender account is required.";
+  } else if (!isStellarAccount(senderTrimmed)) {
+    errors.sender =
+      "Must be a valid Stellar account ID (starts with G, exactly 56 characters, alphanumeric).";
+  }
+
+  // --- Recipient ---
+  const recipientTrimmed = values.recipient.trim();
+  if (!recipientTrimmed) {
+    errors.recipient = "Recipient account is required.";
+  } else if (!isStellarAccount(recipientTrimmed)) {
+    errors.recipient =
+      "Must be a valid Stellar account ID (starts with G, exactly 56 characters, alphanumeric).";
+  }
+
+  if (
+    senderTrimmed &&
+    recipientTrimmed &&
+    isStellarAccount(senderTrimmed) &&
+    isStellarAccount(recipientTrimmed) &&
+    senderTrimmed === recipientTrimmed
+  ) {
+    errors.recipient = "Recipient must differ from the sender account.";
+  }
+
+  // --- Asset code ---
+  const assetTrimmed = values.assetCode.trim();
+  if (!assetTrimmed) {
+    errors.assetCode = "Asset code is required.";
+  } else if (!ASSET_CODE_REGEX.test(assetTrimmed)) {
+    errors.assetCode = "Asset code must be 1–12 alphanumeric characters (e.g. USDC, XLM).";
+  }
+
+  // --- Total amount ---
+  const amountNum = Number(values.totalAmount);
+  if (values.totalAmount === "" || isNaN(amountNum)) {
+    errors.totalAmount = "Total amount is required.";
+  } else if (amountNum <= 0) {
+    errors.totalAmount = "Amount must be greater than zero.";
+  }
+
+  // --- Duration ---
+  const durationNum = Number(values.durationHours);
+  if (values.durationHours === "" || isNaN(durationNum)) {
+    errors.durationHours = "Duration is required.";
+  } else if (!Number.isInteger(durationNum) || durationNum < 1) {
+    errors.durationHours = "Duration must be a whole number of hours, minimum 1.";
+  }
+
+  // --- Start in minutes (optional, 0 = start immediately) ---
+  const startNum = Number(values.startInMinutes);
+  if (values.startInMinutes === "" || isNaN(startNum)) {
+    errors.startInMinutes = "Enter 0 to start immediately, or a positive number of minutes.";
+  } else if (!Number.isInteger(startNum) || startNum < 0) {
+    errors.startInMinutes = "Must be 0 or a positive whole number.";
+  }
+
+  return errors;
+}
+
+/** Returns true only when there are zero error keys. */
+export function isFormValid(errors: FieldErrors): boolean {
+  return Object.keys(errors).length === 0;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -61,13 +61,176 @@ body {
 
 .form-grid {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .row {
   display: grid;
   gap: 0.75rem;
 }
+
+/* ── Field groups ──────────────────────────────────────── */
+
+.field-group {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.field-group label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+.field-required {
+  color: #dc2626;
+}
+
+.field-group input {
+  border: 1.5px solid #d1d5db;
+  border-radius: 8px;
+  min-height: 38px;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.9rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  outline: none;
+}
+
+.field-group input:focus {
+  border-color: #0ea5a5;
+  box-shadow: 0 0 0 3px rgba(14, 165, 165, 0.15);
+}
+
+/* Error state */
+.field-group--error input {
+  border-color: #dc2626;
+  background: #fff8f8;
+}
+
+.field-group--error input:focus {
+  border-color: #dc2626;
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.12);
+}
+
+/* ── Field-level error message ─────────────────────────── */
+
+.field-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  color: #dc2626;
+  line-height: 1.4;
+  padding-top: 0.1rem;
+}
+
+.field-error::before {
+  content: "⚠";
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  margin-top: 0.05rem;
+}
+
+/* ── Inline hint (account length tracker, start=0 note) ── */
+
+.field-hint {
+  font-size: 0.78rem;
+  color: #6b7280;
+  line-height: 1.4;
+}
+
+.field-hint--ok {
+  color: #059669;
+}
+
+.field-hint--warn {
+  color: #d97706;
+}
+
+/* ── Summary error shown at bottom of form ─────────────── */
+
+.form-summary-error {
+  margin: 0;
+  font-size: 0.83rem;
+  color: #dc2626;
+  background: #fff1f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+}
+
+/* ── API error box (inside the form card) ──────────────── */
+
+.api-error-box {
+  background: #fff7ed;
+  border: 1.5px solid #fed7aa;
+  border-radius: 8px;
+  padding: 0.65rem 0.8rem;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.api-error-box__title {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  font-size: 0.88rem;
+  color: #92400e;
+}
+
+.api-error-box__icon {
+  font-size: 1rem;
+}
+
+.api-error-box__hint {
+  font-size: 0.82rem;
+  color: #78350f;
+  line-height: 1.5;
+}
+
+/* ── Global error banner (cancel failures, etc.) ───────── */
+
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  background: #fef2f2;
+  border: 1.5px solid #fca5a5;
+  color: #991b1b;
+  border-radius: 8px;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.88rem;
+}
+
+.error-banner__icon {
+  flex-shrink: 0;
+  font-style: normal;
+}
+
+.error-banner span:nth-child(2) {
+  flex: 1;
+}
+
+.error-banner__dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+  color: #991b1b;
+  padding: 0 0.2rem;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+}
+
+.error-banner__dismiss:hover {
+  opacity: 1;
+}
+
+/* ── Legacy label (outside field-groups, e.g. future use) ── */
 
 label {
   display: grid;
@@ -91,6 +254,16 @@ input {
   color: white;
   background: #0ea5a5;
   cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #0c9191;
+}
+
+.btn-primary:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .btn-ghost {
@@ -100,14 +273,16 @@ input {
   background: white;
   cursor: pointer;
   padding: 0.35rem 0.6rem;
+  transition: background 0.12s;
 }
 
-.error-banner {
-  margin-bottom: 1rem;
-  background: #dc2626;
-  color: white;
-  border-radius: 8px;
-  padding: 0.5rem 0.7rem;
+.btn-ghost:hover:not(:disabled) {
+  background: #f9fafb;
+}
+
+.btn-ghost:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .table-wrap {
@@ -202,7 +377,7 @@ td {
 
 @media (min-width: 920px) {
   .layout-grid {
-    grid-template-columns: 340px 1fr;
+    grid-template-columns: 380px 1fr;
   }
 
   .row {


### PR DESCRIPTION
# feat(frontend): improve form validation and API error messaging

## Summary

This PR significantly improves the `CreateStreamForm` user experience by replacing minimal, generic validation with field-level inline errors, real-time Stellar account format checking, numeric input hardening, and actionable API error messages. Closes #5 

---

## Problem

- Form validation was limited to HTML `required` attributes with no format checking.
- Users could submit malformed Stellar account IDs and only discover the error after a round-trip to the API.
- API errors were surfaced as a raw, generic string in a global red banner with no guidance on how to fix them.
- Numeric fields (`amount`, `duration`, `startInMinutes`) accepted invalid characters (`e`, `E`, `+`) allowed by `type="number"` inputs.

---

## Changes

### `src/hooks/useFormValidation.ts` *(new)*

Centralised validation module, keeping the form component focused on rendering:

- **`STELLAR_ACCOUNT_REGEX`** – canonical rule: starts with `G`, exactly 56 characters, Stellar base32 alphabet (A–Z, 2–7).
- **`isStellarAccount()`** – exported helper shared between the live hint component and the full form validator.
- **`validateForm()`** – runs all six field rules and returns a typed `FieldErrors` map with specific, actionable messages per field.
- **`isFormValid()`** – convenience boolean derived from the errors map.

### `src/components/CreateStreamForm.tsx` *(rewritten)*

| Improvement | Detail |
|---|---|
| Touch-aware error display | Errors only appear after a field loses focus or the user presses Submit — no premature red marks while typing. |
| Live Stellar account hint | `<AccountHint>` shows `✓ Valid (56/56)`, `"3 more characters needed (53/56)"`, or `"Must start with G"` as you type. |
| Sender ≠ Recipient guard | Caught client-side with a clear inline message before any API call is made. |
| Numeric key blocking | `e`, `E`, `+` blocked on the amount field; `e`, `E`, `+`, `-`, `.` blocked on integer fields (duration, start delay). |
| Inline API error box | A styled contextual box inside the form card surfaces create-stream API failures — separate from field errors and not a page-level banner. |
| `humaniseApiError()` | Maps raw API error strings to a `{ title, hint }` pair with plain-English guidance (e.g. points users to Stellar Laboratory for invalid account IDs). |
| Submit guard | The button is disabled while the form has known errors after a submit attempt; `aria-busy` is set during submission. |
| Form reset on success | Field values and touched state are cleared after a successful stream creation. |

### `src/App.tsx` *(updated)*

- Split errors into two channels: **`formError`** (create failures → passed into `<CreateStreamForm>` as `apiError`) and **`globalError`** (cancel / bootstrap failures → page-level banner).
- Added `describeGlobalError()` to rewrite network / not-found messages into plain English.
- Global error banner is now **dismissible** via a `×` button.

### `src/index.css` *(updated)*

- `.field-group`, `.field-group--error` — red border + tinted background on invalid inputs with a smooth focus ring.
- `.field-error` — small red text with `⚠` prefix rendered below the relevant input.
- `.field-hint`, `.field-hint--ok` (green), `.field-hint--warn` (amber) — live account-status hints.
- `.api-error-box` — warm orange panel inside the form card for API-level failures.
- `.error-banner` — redesigned global banner with icon, descriptive text, and dismiss button.
- `.form-summary-error` — "Please fix the errors above" notice at the bottom of the form, shown only after a failed submit attempt.
- Hover and disabled states added to `.btn-primary` and `.btn-ghost`.

---

## Acceptance Criteria

- [x] Invalid Stellar account IDs show inline errors with character-count progress.
- [x] Numeric inputs block `e`, `E`, `+`, `-`, `.` where the field only accepts integers or positive decimals.
- [x] API errors are displayed inside the form with a descriptive title and an actionable hint.
- [x] Global errors (cancel, network) appear as a dismissible contextual banner.
- [x] No TypeScript errors (`tsc --noEmit` passes).
- [x] Production build succeeds (`vite build` passes).

---

## Testing

```bash
# Frontend type-check
cd frontend && npx tsc --noEmit

# Production build
cd frontend && npm run build

# Dev server
cd frontend && npm run dev
```

**Manual scenarios to verify:**

1. Type a partial account ID in the Sender field → amber character-count hint appears.
2. Complete a valid 56-char `G…` key → hint turns green.
3. Enter the same key in both Sender and Recipient → inline error on Recipient.
4. Press `e` in the Amount field → keystroke is blocked.
5. Submit with empty fields → all required field errors appear simultaneously.
6. With the backend offline, submit a valid form → orange API error box appears inside the form card, not a page-level banner.
7. Cancel a stream while the backend is offline → dismissible red banner appears at the top of the page.

---

## Screenshots

> _Attach screenshots of: field-level errors, the live account hint (warn & ok states), the API error box, and the global error banner._
<img width="1280" height="800" alt="Screenshot 2026-02-21 at 07 38 02" src="https://github.com/user-attachments/assets/eb34a78d-1b7e-4545-80cc-6dc3ca8f24b2" />
