### PR TITLE
feature: editing stream before time

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,16 +9,16 @@
       "version": "1.0.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^14.5.0",
-        "cors": "^2.8.5",
+        "cors": "^2.8.6",
         "dotenv": "^17.3.1",
-        "express": "^4.18.2",
+        "express": "^4.22.1",
         "swagger-ui-express": "^5.0.1",
         "ws": "^8.14.2"
       },
       "devDependencies": {
-        "@types/cors": "^2.8.17",
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.11.30",
+        "@types/cors": "^2.8.19",
+        "@types/express": "^4.17.25",
+        "@types/node": "^20.19.33",
         "@types/swagger-ui-express": "^4.1.8",
         "@types/ws": "^8.5.10",
         "ts-node-dev": "^2.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,16 +11,16 @@
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^14.5.0",
-    "cors": "^2.8.5",
+    "cors": "^2.8.6",
     "dotenv": "^17.3.1",
-    "express": "^4.18.2",
+    "express": "^4.22.1",
     "swagger-ui-express": "^5.0.1",
     "ws": "^8.14.2"
   },
   "devDependencies": {
-    "@types/cors": "^2.8.17",
-    "@types/express": "^4.17.21",
-    "@types/node": "^20.11.30",
+    "@types/cors": "^2.8.19",
+    "@types/express": "^4.17.25",
+    "@types/node": "^20.19.33",
     "@types/swagger-ui-express": "^4.1.8",
     "@types/ws": "^8.5.10",
     "ts-node-dev": "^2.0.0",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,6 +13,7 @@ import {
   initSoroban,
   refreshStreamStatuses,
   syncStreams,
+  updateStreamStartAt,
   StreamInput,
 } from "./services/streamStore";
 
@@ -152,6 +153,33 @@ app.post("/api/streams/:id/cancel", async (req: Request, res: Response) => {
   } catch (err: any) {
     console.error("Failed to cancel stream:", err);
     res.status(500).json({ error: err.message || "Failed to cancel stream." });
+  }
+});
+
+app.patch("/api/streams/:id/start-time", (req: Request, res: Response) => {
+  const newStartAt = toNumber(req.body?.startAt);
+
+  if (newStartAt === null || newStartAt <= 0) {
+    res.status(400).json({ error: "startAt must be a valid UNIX timestamp in seconds." });
+    return;
+  }
+
+  if (Math.floor(newStartAt) <= Math.floor(Date.now() / 1000)) {
+    res.status(400).json({ error: "startAt must be in the future." });
+    return;
+  }
+
+  try {
+    const stream = updateStreamStartAt(req.params.id, Math.floor(newStartAt));
+    res.json({
+      data: {
+        ...stream,
+        progress: calculateProgress(stream),
+      },
+    });
+  } catch (err: any) {
+    const statusCode = (err as any).statusCode ?? 500;
+    res.status(statusCode).json({ error: err.message || "Failed to update stream start time." });
   }
 });
 

--- a/backend/src/swagger.ts
+++ b/backend/src/swagger.ts
@@ -311,6 +311,89 @@ export const swaggerDocument = {
                 },
             },
         },
+        "/api/streams/{id}/start-time": {
+            patch: {
+                summary: "Update start time of a scheduled stream",
+                description:
+                    "Updates the startAt timestamp of a stream. Only streams with status **scheduled** can be edited. Active, completed, and canceled streams will be rejected with a 422 error.",
+                parameters: [
+                    {
+                        name: "id",
+                        in: "path",
+                        required: true,
+                        description: "The unique ID of the stream to update.",
+                        schema: {
+                            type: "string",
+                        },
+                    },
+                ],
+                requestBody: {
+                    required: true,
+                    content: {
+                        "application/json": {
+                            schema: {
+                                type: "object",
+                                required: ["startAt"],
+                                properties: {
+                                    startAt: {
+                                        type: "number",
+                                        description: "New start time as a UNIX timestamp in seconds. Must be in the future.",
+                                        example: 1716400000,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                responses: {
+                    "200": {
+                        description: "Start time updated successfully.",
+                        content: {
+                            "application/json": {
+                                schema: {
+                                    type: "object",
+                                    properties: {
+                                        data: {
+                                            $ref: "#/components/schemas/Stream",
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    "400": {
+                        description: "Missing or invalid startAt value.",
+                        content: {
+                            "application/json": {
+                                schema: {
+                                    $ref: "#/components/schemas/Error",
+                                },
+                            },
+                        },
+                    },
+                    "404": {
+                        description: "Stream not found.",
+                        content: {
+                            "application/json": {
+                                schema: {
+                                    $ref: "#/components/schemas/Error",
+                                },
+                            },
+                        },
+                    },
+                    "422": {
+                        description: "Stream is not in scheduled status and cannot be edited.",
+                        content: {
+                            "application/json": {
+                                schema: {
+                                    $ref: "#/components/schemas/Error",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
         "/api/open-issues": {
             get: {
                 summary: "Get Open Issues",

--- a/frontend/src/components/EditStartTimeModal.tsx
+++ b/frontend/src/components/EditStartTimeModal.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useRef, useState } from "react";
+import { Stream } from "../types/stream";
+
+interface EditStartTimeModalProps {
+    stream: Stream;
+    onConfirm: (streamId: string, newStartAt: number) => Promise<void>;
+    onClose: () => void;
+}
+
+/** Convert a UNIX timestamp (seconds) to a datetime-local string value */
+function toDatetimeLocal(unixSeconds: number): string {
+    const d = new Date(unixSeconds * 1000);
+    // Pad helper
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const yyyy = d.getFullYear();
+    const MM = pad(d.getMonth() + 1);
+    const dd = pad(d.getDate());
+    const hh = pad(d.getHours());
+    const mm = pad(d.getMinutes());
+    return `${yyyy}-${MM}-${dd}T${hh}:${mm}`;
+}
+
+/** Convert a datetime-local string to a UNIX timestamp in seconds */
+function fromDatetimeLocal(value: string): number {
+    return Math.floor(new Date(value).getTime() / 1000);
+}
+
+export function EditStartTimeModal({
+    stream,
+    onConfirm,
+    onClose,
+}: EditStartTimeModalProps) {
+    const [value, setValue] = useState<string>(() =>
+        toDatetimeLocal(stream.startAt),
+    );
+    const [fieldError, setFieldError] = useState<string | null>(null);
+    const [apiError, setApiError] = useState<string | null>(null);
+    const [loading, setLoading] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    // Auto-focus the input when modal opens
+    useEffect(() => {
+        inputRef.current?.focus();
+    }, []);
+
+    // Close on Escape
+    useEffect(() => {
+        function onKey(e: KeyboardEvent) {
+            if (e.key === "Escape") onClose();
+        }
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [onClose]);
+
+    function validate(): number | null {
+        setFieldError(null);
+        if (!value) {
+            setFieldError("Please select a date and time.");
+            return null;
+        }
+        const ts = fromDatetimeLocal(value);
+        if (isNaN(ts)) {
+            setFieldError("Invalid date/time.");
+            return null;
+        }
+        const nowSec = Math.floor(Date.now() / 1000);
+        if (ts <= nowSec) {
+            setFieldError("Start time must be in the future.");
+            return null;
+        }
+        return ts;
+    }
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        const ts = validate();
+        if (ts === null) return;
+
+        setApiError(null);
+        setLoading(true);
+        try {
+            await onConfirm(stream.id, ts);
+            onClose();
+        } catch (err) {
+            setApiError(err instanceof Error ? err.message : "Failed to update start time.");
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    // min is 1 minute from now so the browser native picker reflects the constraint
+    const minDatetime = toDatetimeLocal(Math.floor(Date.now() / 1000) + 60);
+
+    return (
+        /* backdrop */
+        <div
+            className="modal-backdrop"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="edit-start-time-title"
+            onClick={(e) => {
+                if (e.target === e.currentTarget) onClose();
+            }}
+        >
+            <div className="modal-panel">
+                {/* Header */}
+                <div className="modal-header">
+                    <h3 id="edit-start-time-title" className="modal-title">
+                        Edit Start Time
+                    </h3>
+                    <button
+                        type="button"
+                        className="modal-close"
+                        aria-label="Close"
+                        onClick={onClose}
+                    >
+                        ✕
+                    </button>
+                </div>
+
+                {/* Stream context */}
+                <p className="modal-stream-hint">
+                    Stream&nbsp;<strong>#{stream.id}</strong>&nbsp;·&nbsp;
+                    {stream.totalAmount}&nbsp;{stream.assetCode}
+                </p>
+
+                <form onSubmit={handleSubmit} noValidate>
+                    <div className={`field-group${fieldError ? " field-group--error" : ""}`}>
+                        <label htmlFor="edit-start-time-input">
+                            New start time <span className="field-required">*</span>
+                        </label>
+                        <input
+                            id="edit-start-time-input"
+                            ref={inputRef}
+                            type="datetime-local"
+                            value={value}
+                            min={minDatetime}
+                            onChange={(e) => {
+                                setValue(e.target.value);
+                                setFieldError(null);
+                            }}
+                        />
+                        {fieldError && <p className="field-error">{fieldError}</p>}
+                    </div>
+
+                    {apiError && (
+                        <div className="api-error-box" role="alert">
+                            <div className="api-error-box__title">
+                                <span className="api-error-box__icon">⚠️</span>
+                                Update failed
+                            </div>
+                            <p className="api-error-box__hint">{apiError}</p>
+                        </div>
+                    )}
+
+                    <div className="modal-actions">
+                        <button
+                            type="button"
+                            className="btn-ghost"
+                            onClick={onClose}
+                            disabled={loading}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            className="btn-primary"
+                            id="edit-start-time-submit"
+                            disabled={loading}
+                        >
+                            {loading ? "Saving…" : "Save"}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/StreamsTable.tsx
+++ b/frontend/src/components/StreamsTable.tsx
@@ -3,6 +3,7 @@ import { Stream } from "../types/stream";
 interface StreamsTableProps {
   streams: Stream[];
   onCancel: (streamId: string) => Promise<void>;
+  onEditStartTime: (stream: Stream) => void;
 }
 
 function statusClass(status: Stream["progress"]["status"]): string {
@@ -24,7 +25,7 @@ function formatTimestamp(unixSeconds: number): string {
   return new Date(unixSeconds * 1000).toLocaleString();
 }
 
-export function StreamsTable({ streams, onCancel }: StreamsTableProps) {
+export function StreamsTable({ streams, onCancel, onEditStartTime }: StreamsTableProps) {
   if (streams.length === 0) {
     return (
       <div className="card">
@@ -46,51 +47,70 @@ export function StreamsTable({ streams, onCancel }: StreamsTableProps) {
               <th>Asset</th>
               <th>Progress</th>
               <th>Status</th>
-              <th>Action</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
-            {streams.map((stream) => (
-              <tr key={stream.id}>
-                <td>{stream.id}</td>
-                <td>
-                  <div className="stacked">
-                    <span>{stream.sender.slice(0, 8)}...</span>
-                    <span>{stream.recipient.slice(0, 8)}...</span>
-                  </div>
-                </td>
-                <td>
-                  {stream.totalAmount} {stream.assetCode}
-                  <div className="muted">
-                    Start: {formatTimestamp(stream.startAt)}
-                  </div>
-                </td>
-                <td>
-                  <div className="progress-copy">
-                    <strong>{stream.progress.percentComplete}%</strong>
-                    <span className="muted">
-                      Vested: {stream.progress.vestedAmount} {stream.assetCode}
+            {streams.map((stream) => {
+              const isScheduled = stream.progress.status === "scheduled";
+              const isFinalised =
+                stream.progress.status === "completed" ||
+                stream.progress.status === "canceled";
+
+              return (
+                <tr key={stream.id}>
+                  <td>{stream.id}</td>
+                  <td>
+                    <div className="stacked">
+                      <span>{stream.sender.slice(0, 8)}...</span>
+                      <span>{stream.recipient.slice(0, 8)}...</span>
+                    </div>
+                  </td>
+                  <td>
+                    {stream.totalAmount} {stream.assetCode}
+                    <div className="muted">Start: {formatTimestamp(stream.startAt)}</div>
+                  </td>
+                  <td>
+                    <div className="progress-copy">
+                      <strong>{stream.progress.percentComplete}%</strong>
+                      <span className="muted">
+                        Vested: {stream.progress.vestedAmount} {stream.assetCode}
+                      </span>
+                    </div>
+                    <div className="progress-bar" aria-hidden>
+                      <div style={{ width: `${Math.min(stream.progress.percentComplete, 100)}%` }} />
+                    </div>
+                  </td>
+                  <td>
+                    <span className={statusClass(stream.progress.status)}>
+                      {stream.progress.status}
                     </span>
-                  </div>
-                  <div className="progress-bar" aria-hidden>
-                    <div style={{ width: `${Math.min(stream.progress.percentComplete, 100)}%` }} />
-                  </div>
-                </td>
-                <td>
-                  <span className={statusClass(stream.progress.status)}>{stream.progress.status}</span>
-                </td>
-                <td>
-                  <button
-                    className="btn-ghost"
-                    type="button"
-                    onClick={() => onCancel(stream.id)}
-                    disabled={stream.progress.status === "completed" || stream.progress.status === "canceled"}
-                  >
-                    Cancel
-                  </button>
-                </td>
-              </tr>
-            ))}
+                  </td>
+                  <td>
+                    <div className="action-cell">
+                      {isScheduled && (
+                        <button
+                          className="btn-ghost btn-edit"
+                          type="button"
+                          title="Edit start time"
+                          onClick={() => onEditStartTime(stream)}
+                        >
+                          ✏️ Edit
+                        </button>
+                      )}
+                      <button
+                        className="btn-ghost"
+                        type="button"
+                        onClick={() => onCancel(stream.id)}
+                        disabled={isFinalised}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -321,7 +321,7 @@ td {
   margin-top: 0.3rem;
 }
 
-.progress-bar > div {
+.progress-bar>div {
   height: 100%;
   background: #0ea5a5;
 }
@@ -383,4 +383,91 @@ td {
   .row {
     grid-template-columns: 1fr 1fr;
   }
+}
+
+/* ── Action cell (Edit + Cancel side-by-side) ──────────── */
+
+.action-cell {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.btn-edit {
+  font-size: 0.8rem;
+  color: #0369a1;
+  border-color: #bae6fd;
+  background: #f0f9ff;
+}
+
+.btn-edit:hover:not(:disabled) {
+  background: #e0f2fe;
+}
+
+/* ── Modal ─────────────────────────────────────────────── */
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+  backdrop-filter: blur(2px);
+}
+
+.modal-panel {
+  background: white;
+  border-radius: 14px;
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.18);
+  display: grid;
+  gap: 1rem;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.95rem;
+  color: #6b7280;
+  padding: 0.2rem 0.4rem;
+  border-radius: 6px;
+  transition: background 0.12s, color 0.12s;
+}
+
+.modal-close:hover {
+  background: #f3f4f6;
+  color: #111827;
+}
+
+.modal-stream-hint {
+  margin: -0.25rem 0 0;
+  font-size: 0.82rem;
+  color: #6b7280;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  margin-top: 0.25rem;
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -34,6 +34,19 @@ export async function cancelStream(streamId: string): Promise<Stream> {
   return body.data;
 }
 
+export async function updateStreamStartAt(
+  streamId: string,
+  startAt: number,
+): Promise<Stream> {
+  const response = await fetch(`${API_BASE}/streams/${streamId}/start-time`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ startAt }),
+  });
+  const body = await parseResponse<{ data: Stream }>(response);
+  return body.data;
+}
+
 export async function listOpenIssues(): Promise<OpenIssue[]> {
   const response = await fetch(`${API_BASE}/open-issues`);
   const body = await parseResponse<{ data: OpenIssue[] }>(response);


### PR DESCRIPTION
## PR Description

This PR implements the ability to edit the start time of a customized, scheduled money stream before it begins vesting. Previously, if users made a mistake with the start time, they were forced to fully cancel the stream and complete the creation flow over again from scratch.

This feature encompasses a new set of targeted updates across the full stack (UI, Service layer, and Backend Controller), adding flexible editing strictly gated to upcoming/scheduled streams. Closes #17