### PR TITLE
feat: add Freighter wallet connect/disconnect (#2)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,8 @@ import { CreateStreamForm } from "./components/CreateStreamForm";
 import { EditStartTimeModal } from "./components/EditStartTimeModal";
 import { IssueBacklog } from "./components/IssueBacklog";
 import { StreamsTable } from "./components/StreamsTable";
+import { WalletButton } from "./components/WalletButton";
+import { useFreighter } from "./hooks/useFreighter";
 import {
   cancelStream,
   createStream,
@@ -28,6 +30,7 @@ function describeGlobalError(raw: string): string {
 }
 
 function App() {
+  const wallet = useFreighter();
   const [streams, setStreams] = useState<Stream[]>([]);
   const [issues, setIssues] = useState<OpenIssue[]>([]);
   const [globalError, setGlobalError] = useState<string | null>(null);
@@ -116,8 +119,13 @@ function App() {
   return (
     <div className="app-shell">
       <header className="hero">
-        <p className="eyebrow">Soroban-native MVP</p>
-        <h1>StellarStream</h1>
+        <div className="hero-top">
+          <div>
+            <p className="eyebrow">Soroban-native MVP</p>
+            <h1>StellarStream</h1>
+          </div>
+          <WalletButton wallet={wallet} />
+        </div>
         <p className="hero-copy">
           Continuous on-chain style payments for salaries, subscriptions, and freelancer payouts on
           Stellar.
@@ -163,7 +171,11 @@ function App() {
 
       <section className="layout-grid">
         {/* formError is passed into the form so the create-stream card can show it inline */}
-        <CreateStreamForm onCreate={handleCreate} apiError={formError} />
+        <CreateStreamForm
+          onCreate={handleCreate}
+          apiError={formError}
+          walletAddress={wallet.address}
+        />
         <StreamsTable
           streams={streams}
           onCancel={handleCancel}

--- a/frontend/src/components/WalletButton.tsx
+++ b/frontend/src/components/WalletButton.tsx
@@ -1,0 +1,62 @@
+import { FreighterState } from "../hooks/useFreighter";
+
+interface WalletButtonProps {
+  wallet: FreighterState;
+}
+
+/** Truncates a Stellar public key to "GABC…WXYZ" format for display. */
+function truncateAddress(addr: string): string {
+  return `${addr.slice(0, 4)}…${addr.slice(-4)}`;
+}
+
+export function WalletButton({ wallet }: WalletButtonProps) {
+  const { installed, address, status, error, connect, disconnect } = wallet;
+
+  if (status === "connected" && address) {
+    return (
+      <div className="wallet-status">
+        <span className="wallet-address" title={address}>
+          <span className="wallet-dot wallet-dot--connected" aria-hidden />
+          {truncateAddress(address)}
+        </span>
+        <button
+          className="btn-ghost wallet-disconnect"
+          type="button"
+          onClick={disconnect}
+        >
+          Disconnect
+        </button>
+      </div>
+    );
+  }
+
+  if (status === "connecting") {
+    return (
+      <button className="btn-primary wallet-btn" type="button" disabled aria-busy>
+        Connecting…
+      </button>
+    );
+  }
+
+  return (
+    <div className="wallet-status">
+      {error && (
+        <span className="wallet-error" role="alert">
+          {error}
+        </span>
+      )}
+      <button
+        className="btn-primary wallet-btn"
+        type="button"
+        onClick={connect}
+        title={
+          !installed
+            ? "Freighter extension not detected — install it from freighter.app"
+            : "Connect your Freighter wallet"
+        }
+      >
+        {!installed ? "Install Freighter" : "Connect Wallet"}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useFreighter.ts
+++ b/frontend/src/hooks/useFreighter.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  isConnected,
+  isAllowed,
+  requestAccess,
+  getPublicKey,
+} from "@stellar/freighter-api";
+
+export type WalletStatus = "idle" | "connecting" | "connected" | "error";
+
+export interface FreighterState {
+  /** Whether the Freighter extension is installed in the browser. */
+  installed: boolean;
+  /** Whether the user has authorized this app in Freighter. */
+  allowed: boolean;
+  /** The connected wallet's Stellar public key, or null if not connected. */
+  address: string | null;
+  status: WalletStatus;
+  /** Human-readable error message, or null when there is no error. */
+  error: string | null;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+}
+
+export function useFreighter(): FreighterState {
+  const [installed, setInstalled] = useState(false);
+  const [allowed, setAllowed] = useState(false);
+  const [address, setAddress] = useState<string | null>(null);
+  const [status, setStatus] = useState<WalletStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  // On mount: detect extension and restore an already-allowed session.
+  useEffect(() => {
+    let cancelled = false;
+
+    async function detect() {
+      try {
+        const connected = await isConnected();
+        if (cancelled) return;
+
+        if (!connected) {
+          setInstalled(false);
+          return;
+        }
+        setInstalled(true);
+
+        const permitted = await isAllowed();
+        if (cancelled) return;
+
+        if (permitted) {
+          const pk = await getPublicKey();
+          if (cancelled) return;
+          if (pk) {
+            setAllowed(true);
+            setAddress(pk);
+            setStatus("connected");
+          }
+        }
+      } catch {
+        // Extension not available — silently ignore on initial probe.
+      }
+    }
+
+    void detect();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const connect = useCallback(async () => {
+    setError(null);
+    setStatus("connecting");
+    try {
+      const pk = await requestAccess();
+      if (!pk) throw new Error("Freighter did not return an account address.");
+      setInstalled(true);
+      setAllowed(true);
+      setAddress(pk);
+      setStatus("connected");
+    } catch (err) {
+      const msg =
+        err instanceof Error ? err.message : "Failed to connect to Freighter.";
+      // User rejected → friendly message
+      const friendly = msg.toLowerCase().includes("user declined")
+        ? "Connection cancelled — please approve the request in Freighter."
+        : msg;
+      setError(friendly);
+      setStatus("error");
+    }
+  }, []);
+
+  const disconnect = useCallback(() => {
+    setAddress(null);
+    setAllowed(false);
+    setStatus("idle");
+    setError(null);
+  }, []);
+
+  return { installed, allowed, address, status, error, connect, disconnect };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -471,3 +471,91 @@ td {
   justify-content: flex-end;
   margin-top: 0.25rem;
 }
+
+/* ── Hero top bar (title + wallet button) ──────────────── */
+
+.hero-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+/* ── Wallet connect / status ───────────────────────────── */
+
+.wallet-btn {
+  white-space: nowrap;
+  font-size: 0.88rem;
+  padding: 0.4rem 0.85rem;
+  min-height: 36px;
+}
+
+.wallet-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.wallet-address {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #1f2937;
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+}
+
+.wallet-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.wallet-dot--connected {
+  background: #22c55e;
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.25);
+}
+
+.wallet-disconnect {
+  font-size: 0.82rem;
+  padding: 0.25rem 0.55rem;
+  min-height: 30px;
+}
+
+.wallet-error {
+  font-size: 0.8rem;
+  color: #dc2626;
+  max-width: 220px;
+}
+
+/* ── Wallet-required notice inside the form ────────────── */
+
+.wallet-required-notice {
+  margin: 0;
+  font-size: 0.83rem;
+  color: #0369a1;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+}
+
+/* ── Read-only sender input (auto-filled from wallet) ───── */
+
+.input-readonly {
+  background: #f9fafb !important;
+  color: #6b7280 !important;
+  cursor: default;
+}
+
+.input-readonly:focus {
+  border-color: #d1d5db !important;
+  box-shadow: none !important;
+}


### PR DESCRIPTION


Closes #2 — replaces the manual sender text input with a real Freighter wallet integration.

- **Connect / Disconnect button** added to the app header via a new `WalletButton` component. Shows a green-dot pill with the truncated address when connected, and surfaces Freighter errors inline.
- **Auto-fill sender** — when a wallet is connected the Sender Account field in the Create Stream form is automatically populated with the wallet's public key and becomes read-only so it cannot be accidentally edited.
- **Wallet-connection gate** — the Create Stream button is disabled and an informational notice is shown when no wallet is connected. `handleSubmit` also guards against submission without a wallet as a second line of defence.
- **Session restore** — on page load the hook checks `isAllowed()` + `getPublicKey()` so a previously-authorized wallet is reconnected without requiring the user to click Connect again.

## Changed files

| File | Change |
|------|--------|
| `frontend/src/hooks/useFreighter.ts` | New — custom hook wrapping `@stellar/freighter-api` (detect, connect, disconnect, session restore) |
| `frontend/src/components/WalletButton.tsx` | New — header connect/disconnect button with four visual states |
| `frontend/src/App.tsx` | Use `useFreighter`, render `WalletButton` in hero, pass `walletAddress` to form |
| `frontend/src/components/CreateStreamForm.tsx` | Accept `walletAddress` prop, auto-fill + lock sender field, gate submit |
| `frontend/src/index.css` | Wallet button, address pill, read-only input, and wallet-required notice styles |

## Acceptance criteria

- [x] User can connect Freighter from the UI
- [x] Sender account is loaded from the connected wallet
- [x] Stream creation flow validates wallet connection (button disabled + submit guard)

## Test plan

1. Open the app without the Freighter extension installed — button reads **Install Freighter**.
2. Install Freighter and open the app — button reads **Connect Wallet**.
3. Click **Connect Wallet** → approve in the Freighter popup → address pill appears in the header and the Sender field auto-fills with your public key (read-only).
4. Try submitting the form before connecting — button is disabled and the notice "Connect your Freighter wallet to create a stream" is visible.
5. Fill in Recipient, Asset, Amount, Duration, and click **Create Stream** — stream is created with your wallet address as the sender.
6. Click **Disconnect** → address pill disappears, Sender field clears, Create Stream button disables again.
7. Refresh the page with an already-authorized wallet — session is restored automatically without clicking Connect.

### Summary

Closes #2 — replaces the manual sender text input with a real Freighter wallet integration.

- **Connect / Disconnect button** added to the app header via a new `WalletButton` component. Shows a green-dot pill with the truncated address when connected, and surfaces Freighter errors inline.
- **Auto-fill sender** — when a wallet is connected the Sender Account field in the Create Stream form is automatically populated with the wallet's public key and becomes read-only so it cannot be accidentally edited.
- **Wallet-connection gate** — the Create Stream button is disabled and an informational notice is shown when no wallet is connected. `handleSubmit` also guards against submission without a wallet as a second line of defence.
- **Session restore** — on page load the hook checks `isAllowed()` + `getPublicKey()` so a previously-authorized wallet is reconnected without requiring the user to click Connect again.

## Changed files

| File | Change |
|------|--------|
| `frontend/src/hooks/useFreighter.ts` | New — custom hook wrapping `@stellar/freighter-api` (detect, connect, disconnect, session restore) |
| `frontend/src/components/WalletButton.tsx` | New — header connect/disconnect button with four visual states |
| `frontend/src/App.tsx` | Use `useFreighter`, render `WalletButton` in hero, pass `walletAddress` to form |
| `frontend/src/components/CreateStreamForm.tsx` | Accept `walletAddress` prop, auto-fill + lock sender field, gate submit |
| `frontend/src/index.css` | Wallet button, address pill, read-only input, and wallet-required notice styles |

## Acceptance criteria

- [x] User can connect Freighter from the UI
- [x] Sender account is loaded from the connected wallet
- [x] Stream creation flow validates wallet connection (button disabled + submit guard)

## Test plan

1. Open the app without the Freighter extension installed — button reads **Install Freighter**.
2. Install Freighter and open the app — button reads **Connect Wallet**.
3. Click **Connect Wallet** → approve in the Freighter popup → address pill appears in the header and the Sender field auto-fills with your public key (read-only).
4. Try submitting the form before connecting — button is disabled and the notice "Connect your Freighter wallet to create a stream" is visible.
5. Fill in Recipient, Asset, Amount, Duration, and click **Create Stream** — stream is created with your wallet address as the sender.
6. Click **Disconnect** → address pill disappears, Sender field clears, Create Stream button disables again.
7. Refresh the page with an already-authorized wallet — session is restored automatically without clicking Connect.

## Screenshoot
<img width="1194" height="1054" alt="Screenshot 2026-02-22 at 13 59 01" src="https://github.com/user-attachments/assets/c4398683-1cab-44be-a190-d522fb6adb99" />
<img width="1194" height="1054" alt="Screenshot 2026-02-22 at 14 00 58" src="https://github.com/user-attachments/assets/e63f999f-6b4f-45bd-848a-dc7a1d313383" />

