### PR TITLE
feat: integrate Soroban token client for real token transfer on claim

### DIFF
--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -1,27 +1,144 @@
 #![cfg(test)]
-
 extern crate std;
-
 use super::*;
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, Env,
+};
+
+fn create_token(env: &Env, admin: &Address) -> Address {
+    let token_contract_id = env.register_stellar_asset_contract_v2(admin.clone());
+    token_contract_id.address()
+}
 
 #[test]
 fn test_get_next_stream_id() {
     let env = Env::default();
     env.mock_all_auths();
-
     let contract_id = env.register_contract(None, StellarStreamContract);
     let client = StellarStreamContractClient::new(&env, &contract_id);
-
     assert_eq!(client.get_next_stream_id(), 0);
-
+    let admin = Address::generate(&env);
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
-    let token = Address::generate(&env);
-
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &5000);
     client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000);
     assert_eq!(client.get_next_stream_id(), 1);
-
     client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000);
     assert_eq!(client.get_next_stream_id(), 2);
+}
+
+#[test]
+fn test_claim_transfers_tokens_to_recipient() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+    env.ledger().with_mut(|l| l.timestamp = 500);
+    let claimed = client.claim(&stream_id, &recipient, &500);
+    assert_eq!(claimed, 500);
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&recipient), 500);
+}
+
+#[test]
+fn test_claim_partial_then_full() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+    env.ledger().with_mut(|l| l.timestamp = 500);
+    client.claim(&stream_id, &recipient, &300);
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+    client.claim(&stream_id, &recipient, &700);
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&recipient), 1000);
+}
+
+#[test]
+#[should_panic(expected = "amount exceeds claimable")]
+fn test_claim_cannot_exceed_vested_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+    env.ledger().with_mut(|l| l.timestamp = 250);
+    client.claim(&stream_id, &recipient, &500);
+}
+
+#[test]
+#[should_panic(expected = "amount exceeds claimable")]
+fn test_claim_cannot_double_claim() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+    env.ledger().with_mut(|l| l.timestamp = 500);
+    client.claim(&stream_id, &recipient, &500);
+    client.claim(&stream_id, &recipient, &500);
+}
+
+#[test]
+#[should_panic(expected = "recipient mismatch")]
+fn test_claim_fails_with_wrong_recipient() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let wrong_recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+    env.ledger().with_mut(|l| l.timestamp = 500);
+    client.claim(&stream_id, &wrong_recipient, &500);
+}
+
+#[test]
+#[should_panic(expected = "insufficient sender balance")]
+fn test_create_stream_fails_with_insufficient_sender_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &100);
+    client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
 }


### PR DESCRIPTION
## Closes #3

Previously, `claim()` only updated internal accounting and did not actually transfer tokens to the recipient.

This PR integrates the Soroban token client so claims now execute real on-chain token transfers using an escrow pattern.

---

## Changes

### contracts/src/lib.rs

- Imported `token::Client` from `soroban_sdk`

#### create_stream
- Added `sender.require_auth()`
- Added sender balance check
- Transfers full `total_amount` from sender into contract escrow on creation

#### claim
- Added `recipient.require_auth()`
- Transfers vested amount from contract escrow to recipient

#### cancel
- Added `sender.require_auth()`
- Refunds remaining unclaimed tokens back to sender

---

### contracts/src/test.rs

- Added 6 tests covering all acceptance criteria

---

## How It Works

On stream creation, the full token amount is transferred into escrow (held by the contract).

On each `claim()`, the contract calculates the vested amount and transfers it directly to the recipient.

On `cancel()`, any unclaimed tokens are refunded to the sender.

This ensures:

- Tokens are secured upfront
- No repeated sender authorization on every claim
- Real on-chain transfers occur during claims

---

## Tests Added

- `test_claim_transfers_tokens_to_recipient`
- `test_claim_partial_then_full`
- `test_claim_cannot_exceed_vested_amount`
- `test_claim_cannot_double_claim`
- `test_claim_fails_with_wrong_recipient`
- `test_create_stream_fails_with_insufficient_sender_balance`

---

## Acceptance Criteria

- ✅ Claim transfers tokens to recipient  
- ✅ Claimed amount cannot exceed vested amount  
- ✅ Contract tests cover both success and failure scenarios  