### PR TITLE
feat(backend): add request ID and structured logging middleware

### DIFF
--- a/backend/src/middleware/requestLogger.ts
+++ b/backend/src/middleware/requestLogger.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from "express";
+import crypto from "crypto";
+
+declare global {
+  namespace Express {
+    interface Request {
+      requestId?: string;
+    }
+  }
+}
+
+export function requestLogger(req: Request, res: Response, next: NextFunction) {
+  const requestId = crypto.randomUUID();
+  req.requestId = requestId;
+  const start = Date.now();
+
+  res.on("finish", () => {
+    const duration = Date.now() - start;
+    const logEntry = {
+      requestId,
+      method: req.method,
+      route: req.originalUrl,
+      statusCode: res.statusCode,
+      duration: `${duration}ms`,
+    };
+
+    console.log(JSON.stringify(logEntry));
+  });
+
+  next();
+}


### PR DESCRIPTION
This PR adds a structured JSON logging middleware to track requests and associate them with unique request IDs for easier debugging. It also fixes multiple upstream syntax errors (missing [parseInput](cci:1://file:///Users/mac/Desktop/Drips/wave/stellar-stream/backend/src/index.ts:52:0-123:1), missing [startServer](cci:1://file:///Users/mac/Desktop/Drips/wave/stellar-stream/backend/src/index.ts:321:0-327:1) scope, and unimported functions) that were preventing the backend from successfully compiling or running.
### Changes Made
- **Created [requestLogger.ts](cci:7://file:///Users/mac/Desktop/Drips/wave/stellar-stream/backend/src/middleware/requestLogger.ts:0:0-0:0) middleware:** Generates a unique UUID (`requestId`) for every incoming req out of Node's native `crypto` module.
- **Structured HTTP Logs:** The middleware listens to the `res.on('finish')` event and prints a structured JSON log containing `{ requestId, method, route, statusCode, duration }`.
- **Attached `requestId` to Error Responses:** All instances of explicit `.json({ error: ... })` responses in [index.ts](cci:7://file:///Users/mac/Desktop/Drips/wave/stellar-stream/backend/src/index.ts:0:0-0:0) have been updated to also return the `requestId` to the client for tracking failing API calls.
- **Fixed Upstream Build Bugs:**
  - Added the missing [parseInput](cci:1://file:///Users/mac/Desktop/Drips/wave/stellar-stream/backend/src/index.ts:52:0-123:1) implementation signature body.
  - Added missing [startServer()](cci:1://file:///Users/mac/Desktop/Drips/wave/stellar-stream/backend/src/index.ts:321:0-327:1) wrapper scope logic at the bottom of the file.
  - Fixed missing API imports (`authMiddleware`, `verifyChallengeAndIssueToken`, `generateChallenge`, `fetchOpenIssues`).
  - Fixed an undefined variable assignment ([req](cci:1://file:///Users/mac/Desktop/Drips/wave/stellar-stream/backend/src/middleware/requestLogger.ts:11:0-30:1) -> `_req` for the open issues catch block).
### Validation
Verified the following endpoints via `curl` returning proper request IDs locally:
- `GET /api/health`
- Invalid `POST /api/streams/:id/cancel`
- Malformed `GET /api/auth/challenge`

Closes #21 