### PR TITLE
Add Indexer Reconciliation Job For Missing Streams

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,7 @@ import { swaggerDocument } from "./swagger";
 
 import { fetchOpenIssues } from "./services/openIssues";
 import { initIndexer, startIndexer } from "./services/indexer";
+import { startReconciliationJob } from "./services/reconciliationJob";
 import { startWebhookWorker } from "./services/webhookWorker";
 import {
   calculateProgress,
@@ -437,6 +438,9 @@ async function startServer() {
   if (contractId) {
     initIndexer(rpcUrl, contractId, networkPassphrase);
     startIndexer(10000); // Poll every 10 seconds
+    startReconciliationJob(
+      Number(process.env.RECONCILIATION_INTERVAL_MS ?? 60000),
+    );
   } else {
     console.warn("CONTRACT_ID not set, event indexer will not start");
   }

--- a/backend/src/services/eventHistory.ts
+++ b/backend/src/services/eventHistory.ts
@@ -123,3 +123,17 @@ export function countAllEvents(eventType?: StreamEventType): number {
     .get() as { count: number };
   return row.count;
 }
+
+export function streamHasEvent(
+  streamId: string,
+  eventType: StreamEventType,
+): boolean {
+  const db = getDb();
+  const row = db
+    .prepare(
+      `SELECT 1 as present FROM stream_events WHERE stream_id = ? AND event_type = ? LIMIT 1`,
+    )
+    .get(streamId, eventType) as { present: number } | undefined;
+
+  return row !== undefined;
+}

--- a/backend/src/services/reconciliationJob.ts
+++ b/backend/src/services/reconciliationJob.ts
@@ -1,0 +1,50 @@
+import { reconcileMissingStreams } from "./streamStore";
+
+let reconciliationInterval: NodeJS.Timeout | null = null;
+let reconciliationInFlight = false;
+
+async function runReconciliationCycle(): Promise<void> {
+  if (reconciliationInFlight) {
+    console.warn(
+      "[reconciliation] skipping cycle because a previous run is still in progress",
+    );
+    return;
+  }
+
+  reconciliationInFlight = true;
+  try {
+    await reconcileMissingStreams();
+  } finally {
+    reconciliationInFlight = false;
+  }
+}
+
+export function startReconciliationJob(intervalMs = 60000): void {
+  if (reconciliationInterval) {
+    return;
+  }
+
+  console.log(
+    `[reconciliation] starting reconciliation job with ${intervalMs}ms interval`,
+  );
+
+  reconciliationInterval = setInterval(() => {
+    runReconciliationCycle().catch((err) => {
+      console.error("[reconciliation] job cycle failed:", err);
+    });
+  }, intervalMs);
+
+  runReconciliationCycle().catch((err) => {
+    console.error("[reconciliation] initial reconciliation failed:", err);
+  });
+}
+
+export function stopReconciliationJob(): void {
+  if (!reconciliationInterval) {
+    return;
+  }
+
+  clearInterval(reconciliationInterval);
+  reconciliationInterval = null;
+  console.log("[reconciliation] reconciliation job stopped");
+}

--- a/backend/src/services/streamStore.test.ts
+++ b/backend/src/services/streamStore.test.ts
@@ -1,0 +1,290 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredStream = {
+  id: string;
+  sender: string;
+  recipient: string;
+  assetCode: string;
+  totalAmount: number;
+  durationSeconds: number;
+  startAt: number;
+  createdAt: number;
+  canceledAt?: number | null;
+  completedAt?: number | null;
+};
+
+const mockState = vi.hoisted(() => ({
+  nextId: 1,
+  existingStreamIds: new Set<string>(),
+  chainStreams: new Map<number, any>(),
+  upsertedStreams: [] as StoredStream[],
+  createdEventIds: new Set<string>(),
+}));
+
+const dbMocks = vi.hoisted(() => ({
+  initDb: vi.fn(),
+  getDb: vi.fn(),
+}));
+
+const eventHistoryMocks = vi.hoisted(() => ({
+  recordEventWithDb: vi.fn(),
+  streamHasEvent: vi.fn((streamId: string, eventType: string) => {
+    return eventType === "created" && mockState.createdEventIds.has(streamId);
+  }),
+}));
+
+vi.mock("./db", () => dbMocks);
+vi.mock("./eventHistory", () => eventHistoryMocks);
+vi.mock("./webhook", () => ({
+  triggerWebhook: vi.fn(),
+}));
+
+vi.mock("@stellar/stellar-sdk", () => {
+  class MockContract {
+    contractId: string;
+
+    constructor(contractId: string) {
+      this.contractId = contractId;
+    }
+
+    call(method: string, ...args: any[]) {
+      return { method, args };
+    }
+  }
+
+  class MockTransactionBuilder {
+    private operation: any;
+
+    constructor(_sourceAccount: any, _options: any) {}
+
+    addOperation(operation: any) {
+      this.operation = operation;
+      return this;
+    }
+
+    setTimeout(_timeout: number) {
+      return this;
+    }
+
+    build() {
+      return { operation: this.operation };
+    }
+  }
+
+  class MockServer {
+    constructor(_rpcUrl: string) {}
+
+    async getAccount(_pubKey: string) {
+      return { accountId: "mock-account" };
+    }
+
+    async simulateTransaction(tx: any) {
+      const operation = tx.operation;
+      if (operation.method === "get_next_stream_id") {
+        return {
+          kind: "success",
+          result: { retval: mockState.nextId },
+        };
+      }
+
+      if (operation.method === "get_stream") {
+        const streamId = Number(operation.args[0]);
+        const chainStream = mockState.chainStreams.get(streamId);
+        if (!chainStream) {
+          return {
+            kind: "error",
+          };
+        }
+
+        return {
+          kind: "success",
+          result: { retval: chainStream },
+        };
+      }
+
+      throw new Error(`Unexpected contract method: ${operation.method}`);
+    }
+  }
+
+  return {
+    Keypair: {
+      fromSecret: vi.fn(),
+    },
+    rpc: {
+      Server: MockServer,
+      Api: {
+        isSimulationSuccess: (response: any) => response.kind === "success",
+      },
+    },
+    Contract: MockContract,
+    nativeToScVal: (value: any) => value,
+    scValToNative: (value: any) => value,
+    Address: class MockAddress {},
+    TimeoutInfinite: {},
+    TransactionBuilder: MockTransactionBuilder,
+    Networks: {
+      TESTNET: "TESTNET",
+    },
+  };
+});
+
+function createDbMock() {
+  return {
+    prepare(sql: string) {
+      if (sql.includes("SELECT id FROM streams")) {
+        return {
+          all: () =>
+            Array.from(mockState.existingStreamIds).map((id) => ({ id })),
+        };
+      }
+
+      if (sql.includes("INSERT INTO streams")) {
+        return {
+          run: (params: any) => {
+            mockState.existingStreamIds.add(params.id);
+            mockState.upsertedStreams.push({
+              id: params.id,
+              sender: params.sender,
+              recipient: params.recipient,
+              assetCode: params.assetCode,
+              totalAmount: params.totalAmount,
+              durationSeconds: params.durationSeconds,
+              startAt: params.startAt,
+              createdAt: params.createdAt,
+              canceledAt: params.canceledAt,
+              completedAt: params.completedAt,
+            });
+            return { changes: 1 };
+          },
+        };
+      }
+
+      throw new Error(`Unexpected SQL: ${sql}`);
+    },
+    transaction<T extends (...args: any[]) => any>(callback: T): T {
+      return ((...args: Parameters<T>) => callback(...args)) as T;
+    },
+  };
+}
+
+describe("reconcileMissingStreams", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockState.nextId = 1;
+    mockState.existingStreamIds = new Set<string>();
+    mockState.chainStreams = new Map<number, any>();
+    mockState.upsertedStreams = [];
+    mockState.createdEventIds = new Set<string>();
+
+    dbMocks.getDb.mockReturnValue(createDbMock());
+    dbMocks.initDb.mockImplementation(() => undefined);
+
+    process.env.CONTRACT_ID = "test-contract";
+    process.env.RPC_URL = "https://rpc.test";
+    delete process.env.SERVER_PRIVATE_KEY;
+  });
+
+  it("backfills only missing local streams from chain", async () => {
+    mockState.nextId = 4;
+    mockState.existingStreamIds = new Set(["1", "3"]);
+    mockState.chainStreams.set(2, {
+      sender: "GSENDER2",
+      recipient: "GRECIPIENT2",
+      token: "USDC",
+      total_amount: 250,
+      start_time: 100,
+      end_time: 160,
+      canceled: false,
+    });
+
+    const { initSoroban, reconcileMissingStreams } = await import("./streamStore");
+
+    await initSoroban();
+    const repaired = await reconcileMissingStreams();
+
+    expect(repaired).toBe(1);
+    expect(mockState.upsertedStreams).toHaveLength(1);
+    expect(mockState.upsertedStreams[0]).toMatchObject({
+      id: "2",
+      sender: "GSENDER2",
+      recipient: "GRECIPIENT2",
+      assetCode: "USDC",
+      totalAmount: 250,
+      durationSeconds: 60,
+    });
+    expect(eventHistoryMocks.recordEventWithDb).toHaveBeenCalledTimes(1);
+    expect(eventHistoryMocks.recordEventWithDb).toHaveBeenCalledWith(
+      expect.anything(),
+      "2",
+      "created",
+      100,
+      "GSENDER2",
+      250,
+      expect.objectContaining({
+        recipient: "GRECIPIENT2",
+        assetCode: "USDC",
+        durationSeconds: 60,
+        source: "reconciliation",
+      }),
+    );
+  });
+
+  it("is safe to run more than once without duplicating indexed streams", async () => {
+    mockState.nextId = 3;
+    mockState.chainStreams.set(1, {
+      sender: "GSENDER1",
+      recipient: "GRECIPIENT1",
+      token: "USDC",
+      total_amount: 100,
+      start_time: 10,
+      end_time: 20,
+      canceled: false,
+    });
+    mockState.chainStreams.set(2, {
+      sender: "GSENDER2",
+      recipient: "GRECIPIENT2",
+      token: "USDC",
+      total_amount: 200,
+      start_time: 30,
+      end_time: 50,
+      canceled: false,
+    });
+
+    const { initSoroban, reconcileMissingStreams } = await import("./streamStore");
+
+    await initSoroban();
+    const firstRunCount = await reconcileMissingStreams();
+    mockState.createdEventIds = new Set(["1", "2"]);
+    const secondRunCount = await reconcileMissingStreams();
+
+    expect(firstRunCount).toBe(2);
+    expect(secondRunCount).toBe(0);
+    expect(mockState.upsertedStreams.map((stream) => stream.id)).toEqual([
+      "1",
+      "2",
+    ]);
+    expect(eventHistoryMocks.recordEventWithDb).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs a clear failure when a missing stream cannot be fetched", async () => {
+    mockState.nextId = 3;
+    mockState.existingStreamIds = new Set(["1"]);
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const { initSoroban, reconcileMissingStreams } = await import("./streamStore");
+
+    await initSoroban();
+    const repaired = await reconcileMissingStreams();
+
+    expect(repaired).toBe(0);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[reconciliation] missing stream 2 could not be fetched from chain",
+    );
+    expect(eventHistoryMocks.recordEventWithDb).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+});

--- a/backend/src/services/streamStore.ts
+++ b/backend/src/services/streamStore.ts
@@ -11,6 +11,7 @@ import {
 } from "@stellar/stellar-sdk";
 import { initDb, getDb } from "./db";
 import { recordEventWithDb } from "./eventHistory";
+import { streamHasEvent } from "./eventHistory";
 import { triggerWebhook } from "./webhook";
 
 export type StreamStatus = "scheduled" | "active" | "completed" | "canceled";
@@ -105,6 +106,12 @@ function upsertStream(record: StreamRecord): void {
   });
 }
 
+function listLocalStreamIds(): Set<string> {
+  const db = getDb();
+  const rows = db.prepare("SELECT id FROM streams").all() as Array<{ id: string }>;
+  return new Set(rows.map((row) => row.id));
+}
+
 let rpcServer: rpc.Server | null = null;
 let serverKeypair: Keypair | null = null;
 
@@ -130,6 +137,121 @@ function nowInSeconds(): number {
 
 function round(value: number): number {
   return Number(value.toFixed(6));
+}
+
+function getSorobanContext():
+  | {
+      contract: Contract;
+      sourceAccountPromise: Promise<rpc.Api.GetAccountResponse>;
+    }
+  | undefined {
+  const contractId = process.env.CONTRACT_ID;
+  if (!contractId || !rpcServer) {
+    return undefined;
+  }
+
+  const pubKey = serverKeypair
+    ? serverKeypair.publicKey()
+    : "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+  return {
+    contract: new Contract(contractId),
+    sourceAccountPromise: rpcServer.getAccount(pubKey),
+  };
+}
+
+async function simulateContractCall(
+  contract: Contract,
+  sourceAccount: rpc.Api.GetAccountResponse,
+  method: string,
+  ...args: any[]
+): Promise<rpc.Api.SimulateTransactionResponse> {
+  if (!rpcServer) {
+    throw new Error("Soroban RPC server is not initialized.");
+  }
+
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: "100",
+    networkPassphrase: process.env.NETWORK_PASSPHRASE || Networks.TESTNET,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  return rpcServer.simulateTransaction(tx);
+}
+
+async function fetchNextOnChainStreamId(
+  contract: Contract,
+  sourceAccount: rpc.Api.GetAccountResponse,
+): Promise<number | null> {
+  const simRes = await simulateContractCall(
+    contract,
+    sourceAccount,
+    "get_next_stream_id",
+  );
+
+  if (!rpc.Api.isSimulationSuccess(simRes) || !simRes.result) {
+    console.warn("[reconciliation] failed to simulate get_next_stream_id", simRes);
+    return null;
+  }
+
+  return Number(scValToNative(simRes.result.retval));
+}
+
+async function fetchOnChainStreamRecord(
+  contract: Contract,
+  sourceAccount: rpc.Api.GetAccountResponse,
+  id: number,
+): Promise<StreamRecord | null> {
+  const simRes = await simulateContractCall(
+    contract,
+    sourceAccount,
+    "get_stream",
+    nativeToScVal(id, { type: "u64" }),
+  );
+
+  if (!rpc.Api.isSimulationSuccess(simRes) || !simRes.result) {
+    return null;
+  }
+
+  const streamData = scValToNative(simRes.result.retval);
+
+  return {
+    id: id.toString(),
+    sender: streamData.sender,
+    recipient: streamData.recipient,
+    assetCode: streamData.token,
+    totalAmount: Number(streamData.total_amount),
+    durationSeconds: Number(streamData.end_time) - Number(streamData.start_time),
+    startAt: Number(streamData.start_time),
+    createdAt: Number(streamData.start_time),
+    canceledAt: streamData.canceled ? nowInSeconds() : undefined,
+  };
+}
+
+function recordBackfilledCreatedEvent(stream: StreamRecord): void {
+  if (streamHasEvent(stream.id, "created")) {
+    return;
+  }
+
+  const db = getDb();
+  db.transaction(() => {
+    recordEventWithDb(
+      db,
+      stream.id,
+      "created",
+      stream.createdAt,
+      stream.sender,
+      stream.totalAmount,
+      {
+        recipient: stream.recipient,
+        assetCode: stream.assetCode,
+        durationSeconds: stream.durationSeconds,
+        source: "reconciliation",
+      },
+    );
+  })();
 }
 
 function computeStatus(stream: StreamRecord, at: number): StreamStatus {
@@ -172,62 +294,104 @@ export function calculateProgress(
 }
 
 export async function syncStreams() {
-  const contractId = process.env.CONTRACT_ID;
-  if (!contractId || !rpcServer) return;
-  const contract = new Contract(contractId);
+  const sorobanContext = getSorobanContext();
+  if (!sorobanContext) return;
 
   try {
-    const pubKey = serverKeypair
-      ? serverKeypair.publicKey()
-      : "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
-    const sourceAccount = await rpcServer.getAccount(pubKey);
-    const tx = new TransactionBuilder(sourceAccount, {
-      fee: "100",
-      networkPassphrase: process.env.NETWORK_PASSPHRASE || Networks.TESTNET,
-    })
-      .addOperation(contract.call("get_next_stream_id"))
-      .setTimeout(30)
-      .build();
-
-    const simRes = await rpcServer.simulateTransaction(tx);
-    if (!rpc.Api.isSimulationSuccess(simRes) || !simRes.result) {
-      console.warn("Failed to simulate get_next_stream_id", simRes);
+    const sourceAccount = await sorobanContext.sourceAccountPromise;
+    const nextId = await fetchNextOnChainStreamId(
+      sorobanContext.contract,
+      sourceAccount,
+    );
+    if (nextId === null) {
       return;
     }
 
-    const nextIdVal = scValToNative(simRes.result.retval);
-    const nextId = Number(nextIdVal);
-
-    for (let i = 1; i <= nextId; i++) {
-      const simTx = new TransactionBuilder(sourceAccount, {
-        fee: "100",
-        networkPassphrase: process.env.NETWORK_PASSPHRASE || Networks.TESTNET,
-      })
-        .addOperation(
-          contract.call("get_stream", nativeToScVal(i, { type: "u64" })),
-        )
-        .setTimeout(30)
-        .build();
-      const simRes2 = await rpcServer.simulateTransaction(simTx);
-      if (rpc.Api.isSimulationSuccess(simRes2) && simRes2.result) {
-        const streamData = scValToNative(simRes2.result.retval);
-
-        upsertStream({
-          id: i.toString(),
-          sender: streamData.sender,
-          recipient: streamData.recipient,
-          assetCode: streamData.token,
-          totalAmount: Number(streamData.total_amount),
-          durationSeconds:
-            Number(streamData.end_time) - Number(streamData.start_time),
-          startAt: Number(streamData.start_time),
-          createdAt: Number(streamData.start_time),
-          canceledAt: streamData.canceled ? nowInSeconds() : undefined,
-        });
+    for (let i = 1; i < nextId; i++) {
+      const stream = await fetchOnChainStreamRecord(
+        sorobanContext.contract,
+        sourceAccount,
+        i,
+      );
+      if (stream) {
+        upsertStream(stream);
       }
     }
   } catch (err) {
     console.error("Failed to sync streams", err);
+  }
+}
+
+export async function reconcileMissingStreams(): Promise<number> {
+  const sorobanContext = getSorobanContext();
+  if (!sorobanContext) {
+    return 0;
+  }
+
+  try {
+    const sourceAccount = await sorobanContext.sourceAccountPromise;
+    const nextId = await fetchNextOnChainStreamId(
+      sorobanContext.contract,
+      sourceAccount,
+    );
+
+    if (nextId === null || nextId <= 1) {
+      console.log("[reconciliation] no on-chain streams available to reconcile");
+      return 0;
+    }
+
+    const localStreamIds = listLocalStreamIds();
+    const missingIds: number[] = [];
+
+    for (let id = 1; id < nextId; id++) {
+      if (!localStreamIds.has(id.toString())) {
+        missingIds.push(id);
+      }
+    }
+
+    if (missingIds.length === 0) {
+      console.log("[reconciliation] no missing local streams detected");
+      return 0;
+    }
+
+    console.warn(
+      `[reconciliation] detected ${missingIds.length} missing local stream(s): ${missingIds.join(", ")}`,
+    );
+
+    let repairedCount = 0;
+    for (const missingId of missingIds) {
+      try {
+        const stream = await fetchOnChainStreamRecord(
+          sorobanContext.contract,
+          sourceAccount,
+          missingId,
+        );
+
+        if (!stream) {
+          console.error(
+            `[reconciliation] missing stream ${missingId} could not be fetched from chain`,
+          );
+          continue;
+        }
+
+        upsertStream(stream);
+        recordBackfilledCreatedEvent(stream);
+        repairedCount += 1;
+      } catch (err) {
+        console.error(
+          `[reconciliation] failed to backfill missing stream ${missingId}:`,
+          err,
+        );
+      }
+    }
+
+    console.log(
+      `[reconciliation] repaired ${repairedCount} missing local stream(s) out of ${missingIds.length}`,
+    );
+    return repairedCount;
+  } catch (err) {
+    console.error("[reconciliation] reconciliation failed:", err);
+    return 0;
   }
 }
 


### PR DESCRIPTION
Close: #69

Added an idempotent reconciliation path for missing streams.

The core change is in streamStore.ts (line 325): reconcileMissingStreams() now compares local stream IDs to on-chain IDs, fetches only missing streams, upserts them safely, and adds a synthetic created event only when one does not already exist. I also refactored the existing startup sync to reuse the same Soroban fetch helpers and fixed its iteration to stop at nextId - 1, which avoids probing the next unused stream ID. To support duplicate-safe event backfill, I added streamHasEvent() in eventHistory.ts (line 127).

The recurring job lives in reconciliationJob.ts (line 1) and is started from index.ts (line 441). It runs immediately, repeats on RECONCILIATION_INTERVAL_MS (default 60000), and skips overlapping cycles so reruns stay safe. Logging is prefixed with [reconciliation] and includes per-stream failures for missing or failed backfills.

