### PR TITLE
fix: correct cancel logic for edge cases and expand test coverage

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -211,10 +211,13 @@ impl StellarStreamContract {
         let min_end = if now > stream.start_time {
             now
         } else {
-            stream.start_time + 1
+            stream.start_time
         };
         if min_end < stream.end_time {
             stream.end_time = min_end;
+            // Adjust total_amount to match the vested amount at cancel time
+            // This ensures that the vested calculation remains correct after truncation
+            stream.total_amount = vested;
         }
 
         if sender_refund > 0 {
@@ -256,7 +259,7 @@ fn vested_amount(stream: &Stream, at_time: u64) -> i128 {
     let total_duration = stream.end_time - stream.start_time;
 
     if total_duration == 0 {
-        return stream.total_amount;
+        return 0;
     }
 
     stream.total_amount * (elapsed as i128) / (total_duration as i128)

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -458,3 +458,445 @@ fn test_event_emissions() {
         }
     );
 }
+
+
+
+// -----------------------------------------------------------------
+// CANCEL BEFORE STREAM START
+// -----------------------------------------------------------------
+
+/// Cancel issued before the stream's start_time.
+/// vested = 0, so the full total_amount must be returned to the sender.
+#[test]
+fn test_cancel_before_start_refunds_full_amount_to_sender() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    // Stream starts at t=500, current ledger time is 0 (before start)
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &500, &1500);
+
+    // Sender balance is 0 after escrow; cancel at t=0 (before start_time=500)
+    env.ledger().with_mut(|l| l.timestamp = 0);
+    client.cancel(&stream_id, &sender);
+
+    let token_client = token::Client::new(&env, &token);
+    // Full amount must come back to sender
+    assert_eq!(token_client.balance(&sender), 1000);
+    // Recipient must have received nothing
+    assert_eq!(token_client.balance(&recipient), 0);
+}
+
+/// After a pre-start cancel the recipient's claimable amount must be zero.
+#[test]
+fn test_cancel_before_start_recipient_claimable_is_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &500, &1500);
+
+    env.ledger().with_mut(|l| l.timestamp = 0);
+    client.cancel(&stream_id, &sender);
+
+    // claimable at any future time must be 0 because end_time was truncated
+    assert_eq!(client.claimable(&stream_id, &1500), 0);
+    assert_eq!(client.claimable(&stream_id, &9999), 0);
+}
+
+/// Attempting to claim any amount after a pre start cancel must panic.
+#[test]
+#[should_panic(expected = "amount exceeds claimable")]
+fn test_cancel_before_start_claim_attempt_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &500, &1500);
+
+    env.ledger().with_mut(|l| l.timestamp = 0);
+    client.cancel(&stream_id, &sender);
+
+    // Advance time well past original end — should still be unclaim­able
+    env.ledger().with_mut(|l| l.timestamp = 2000);
+    client.claim(&stream_id, &recipient, &1);
+}
+
+// -----------------------------------------------------------------
+// CANCEL MID-STREAM — partial vesting refund math
+// -----------------------------------------------------------------
+
+/// Cancel at exactly the 25 % mark.
+/// vested = 250, sender refund = 750, recipient can claim 250.
+#[test]
+fn test_cancel_at_quarter_vesting() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    // Stream: t=0..1000, total=1000 → 1 token er second
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+
+    env.ledger().with_mut(|l| l.timestamp = 250); // 25 % through
+    client.cancel(&stream_id, &sender);
+
+    let token_client = token::Client::new(&env, &token);
+    // Sender must receive the unvested 75 %
+    assert_eq!(token_client.balance(&sender), 750);
+
+    // Recipient can now claim exactly the vested 25 %
+    client.claim(&stream_id, &recipient, &250);
+    assert_eq!(token_client.balance(&recipient), 250);
+}
+
+/// Cancel at exactly the 50 % mark with no prior claims.
+/// vested = 500, sender refund = 500.
+#[test]
+fn test_cancel_midstream_no_prior_claims_splits_correctly() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+
+    env.ledger().with_mut(|l| l.timestamp = 500);
+    client.cancel(&stream_id, &sender);
+
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&sender), 500);
+
+    // Recipient claims vested portion
+    client.claim(&stream_id, &recipient, &500);
+    assert_eq!(token_client.balance(&recipient), 500);
+
+    // Total accounted for = 1000, nothing lost or double-counted
+    assert_eq!(
+        token_client.balance(&sender) + token_client.balance(&recipient),
+        1000
+    );
+}
+
+/// Cancel at 75 % with a non-round total to verify integer arithmetic is exact.
+/// total=1200, duration=1200s, cancel at t=900 (75 %)
+/// vested = 900, sender refund = 300.
+#[test]
+fn test_cancel_midstream_non_round_amounts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1200);
+
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1200, &0, &1200);
+
+    env.ledger().with_mut(|l| l.timestamp = 900); // 75 %
+    client.cancel(&stream_id, &sender);
+
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&sender), 300);
+    assert_eq!(client.claimable(&stream_id, &900), 900);
+}
+
+/// Recipient claims some tokens mid-stream, then sender cancels.
+/// Refund = total - vested (NOT total - claimed); the contract holds
+/// vested - claimed for the recipient and returns total - vested to sender.
+/// total=1000, cancel at t=600 → vested=600, already_claimed=200
+/// sender_refund = 400, remaining_claimable_for_recipient = 400
+#[test]
+fn test_cancel_midstream_after_partial_claim_correct_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+
+    // Recipient claims 200 at t=400 (vested=400 at that point)
+    env.ledger().with_mut(|l| l.timestamp = 400);
+    client.claim(&stream_id, &recipient, &200);
+
+    // Sender cancels at t=600 (vested=600)
+    env.ledger().with_mut(|l| l.timestamp = 600);
+    client.cancel(&stream_id, &sender);
+
+    let token_client = token::Client::new(&env, &token);
+    // Sender gets back 1000 - 600 = 400
+    assert_eq!(token_client.balance(&sender), 400);
+
+    // Recipient already has 200; can claim remaining vested - claimed = 400
+    assert_eq!(client.claimable(&stream_id, &600), 400);
+    client.claim(&stream_id, &recipient, &400);
+    assert_eq!(token_client.balance(&recipient), 600); // 200 + 400
+
+    // Full conservation: 400 (sender) + 600 (recipient) = 1000
+    assert_eq!(
+        token_client.balance(&sender) + token_client.balance(&recipient),
+        1000
+    );
+}
+
+/// After a mid-stream cancel the recipient cannot claim more than what
+/// was vested at cancel time, even if ledger time advances further.
+#[test]
+#[should_panic(expected = "amount exceeds claimable")]
+fn test_cancel_midstream_recipient_cannot_claim_past_cancel_point() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+
+    env.ledger().with_mut(|l| l.timestamp = 500);
+    client.cancel(&stream_id, &sender);
+
+    // Try to claim 501  one more than vested at cancel time
+    env.ledger().with_mut(|l| l.timestamp = 2000); // far future
+    client.claim(&stream_id, &recipient, &501);
+}
+
+// -----------------------------------------------------------------
+// CANCEL AFTER FULL VESTING
+// -----------------------------------------------------------------
+
+/// Cancel exactly at end_time: all tokens are vested, sender gets 0 refund.
+#[test]
+fn test_cancel_at_end_time_sender_gets_zero_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+
+    env.ledger().with_mut(|l| l.timestamp = 1000); // exactly at end
+    client.cancel(&stream_id, &sender);
+
+    let token_client = token::Client::new(&env, &token);
+    // Sender transferred 1000 into escrow and should get 0 back
+    assert_eq!(token_client.balance(&sender), 0);
+}
+
+/// Cancel well after end_time: full amount is vested, sender gets 0 refund.
+#[test]
+fn test_cancel_after_end_time_sender_gets_zero_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+
+    env.ledger().with_mut(|l| l.timestamp = 9999); // long after end
+    client.cancel(&stream_id, &sender);
+
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&sender), 0);
+}
+
+/// After a post-full-vesting cancel the recipient can still claim the
+/// entire total_amount.
+#[test]
+fn test_cancel_after_full_vesting_recipient_can_claim_all() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+
+    env.ledger().with_mut(|l| l.timestamp = 9999);
+    client.cancel(&stream_id, &sender);
+
+    // Recipient should be able to claim the full amount
+    assert_eq!(client.claimable(&stream_id, &9999), 1000);
+    client.claim(&stream_id, &recipient, &1000);
+
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&recipient), 1000);
+}
+
+/// Cancel after full vesting when recipient has already claimed part:
+/// recipient claims the remainder, sender still gets 0.
+#[test]
+fn test_cancel_after_full_vesting_with_partial_prior_claim() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+
+    // recipient claims 300 before stream ends
+    env.ledger().with_mut(|l| l.timestamp = 500);
+    client.claim(&stream_id, &recipient, &300);
+
+    // Sender cancels after full vesting
+    env.ledger().with_mut(|l| l.timestamp = 1500);
+    client.cancel(&stream_id, &sender);
+
+    let token_client = token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&sender), 0);
+
+    // Recipient can claim the remaining 700
+    assert_eq!(client.claimable(&stream_id, &1500), 700);
+    client.claim(&stream_id, &recipient, &700);
+    assert_eq!(token_client.balance(&recipient), 1000);
+}
+
+// -----------------------------------------------------------------
+// CONSERVATION INVARIANT
+// -----------------------------------------------------------------
+
+/// For any cancel timing, the sum of tokens held by sender and recipient
+/// after all claims must equal the original total_amount. This test
+/// exercises three timings in one scenario using three independent streams.
+#[test]
+fn test_cancel_token_conservation_across_timings() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    // Mint enough for three streams of 1200 each
+    token_admin.mint(&sender, &3600);
+
+    let token_client = token::Client::new(&env, &token);
+
+    // --- Stream A: cancel before start ---
+    let a = client.create_stream(&sender, &recipient, &token, &1200, &500, &1700);
+    env.ledger().with_mut(|l| l.timestamp = 100); // before start_time=500
+    let sender_before_a = token_client.balance(&sender);
+    let recipient_before_a = token_client.balance(&recipient);
+    client.cancel(&a, &sender);
+    // Full refund to sender; recipient gets nothing
+    assert_eq!(
+        token_client.balance(&sender) + token_client.balance(&recipient)
+            - sender_before_a
+            - recipient_before_a,
+        1200
+    );
+
+    // --- Stream B: cancel at 50 % ---
+    env.ledger().with_mut(|l| l.timestamp = 0);
+    let b = client.create_stream(&sender, &recipient, &token, &1200, &0, &1200);
+    env.ledger().with_mut(|l| l.timestamp = 600); // 50 %
+    let sender_before_b = token_client.balance(&sender);
+    let recipient_before_b = token_client.balance(&recipient);
+    client.cancel(&b, &sender);
+    client.claim(&b, &recipient, &600);
+    assert_eq!(
+        token_client.balance(&sender) + token_client.balance(&recipient)
+            - sender_before_b
+            - recipient_before_b,
+        1200
+    );
+
+    // --- Stream C: cancel after full vesting ---
+    env.ledger().with_mut(|l| l.timestamp = 0);
+    let c = client.create_stream(&sender, &recipient, &token, &1200, &0, &1200);
+    env.ledger().with_mut(|l| l.timestamp = 9999); // after end
+    let sender_before_c = token_client.balance(&sender);
+    let recipient_before_c = token_client.balance(&recipient);
+    client.cancel(&c, &sender);
+    client.claim(&c, &recipient, &1200);
+    assert_eq!(
+        token_client.balance(&sender) + token_client.balance(&recipient)
+            - sender_before_c
+            - recipient_before_c,
+        1200
+    );
+}


### PR DESCRIPTION
Closes #79 

## Description
Fixed cancel logic edge cases in stellar-stream contract to handle timing scenarios correctly.

## Changes
- Fixed cancel before start: end_time now correctly set to start_time
- Adjusted total_amount when truncating end_time to preserve vested calculations
- Fixed vested_amount edge case when total_duration is 0

## Testing
- All 35 tests pass
- Covers cancel before start, mid-stream, and after full vesting scenarios
- Verified claimed and refundable amounts behave correctly

## Acceptance Criteria
- ✅ Tests cover cancel before stream start
- ✅ Tests cover partial vesting refund math
- ✅ Tests cover cancel after full vesting
- ✅ Claimed and refundable amounts behave as expected
