### PR TITLE
feat(wave4): add typed API errors, stream filtering, websocket updates, and toast notifications

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,88 +1,95 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type RefObject } from "react";
 import { CreateStreamForm } from "./components/CreateStreamForm";
 import { EditStartTimeModal } from "./components/EditStartTimeModal";
 import { IssueBacklog } from "./components/IssueBacklog";
 import { RecipientDashboard } from "./components/RecipientDashboard";
-import { StreamsTable } from "./components/StreamsTable";
-
+import { SenderDashboard } from "./components/SenderDashboard";
+import { StreamDetailDrawer } from "./components/StreamDetailDrawer";
 import { StreamMetricsChart } from "./components/StreamMetricsChart";
-import { WalletButton } from "./components/WalletButton";
 import { StreamTimeline } from "./components/StreamTimeline";
+import { StreamsTable } from "./components/StreamsTable";
+import { WalletButton } from "./components/WalletButton";
 import { useFreighter } from "./hooks/useFreighter";
+import { useMetricsHistory } from "./hooks/useMetricsHistory";
+import { defaultStreamFilters, useStreamFilter } from "./hooks/useStreamFilter";
+import { useToast } from "./hooks/useToast";
+import { useWebSocket } from "./hooks/useWebSocket";
 import {
+  ApiError,
   cancelStream,
   createStream,
+  listOpenIssues,
   listStreams,
   updateStreamStartAt,
 } from "./services/api";
+import { ListStreamsFilters } from "./services/api";
 import { OpenIssue, Stream } from "./types/stream";
-import { useMetricsHistory } from "./hooks/useMetricsHistory";
-import { useUrlFilters } from "./hooks/useUrlFilters";
 
 type ViewMode = "dashboard" | "recipient" | "sender";
 
-// Derive a user-friendly hint string for global (non-form) errors.
-function describeGlobalError(raw: string): string {
-  const lower = raw.toLowerCase();
-  if (
-    lower.includes("network") ||
-    lower.includes("fetch") ||
-    lower.includes("failed to fetch")
-  ) {
-    return "Network error — check that the StellarStream backend is running and reachable.";
-  }
-  if (lower.includes("not found")) {
-    return "The requested stream could not be found. It may have already been cancelled.";
-  }
-  if (lower.includes("cancel")) {
-    return `Unable to cancel stream: ${raw}`;
-  }
-  return raw;
-}
-
 function App() {
   const wallet = useFreighter();
-  const {
-    view: viewMode,
-    filters,
-    streamId: detailStreamId,
-    setView: setViewMode,
-    setFilters,
-    openStream,
-    closeStream,
-  } = useUrlFilters();
+  const { showToast } = useToast();
+  const [viewMode, setViewMode] = useState<ViewMode>("dashboard");
+  const [detailStreamId, setDetailStreamId] = useState<string | null>(null);
   const [streams, setStreams] = useState<Stream[]>([]);
   const [issues, setIssues] = useState<OpenIssue[]>([]);
-  const [globalError, setGlobalError] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [editingStream, setEditingStream] = useState<{
     stream: Stream;
-    triggerRef: React.RefObject<HTMLButtonElement | null>;
+    triggerRef: RefObject<HTMLButtonElement | null>;
   } | null>(null);
   const [loadingDashboard, setLoadingDashboard] = useState(true);
   const [initialLoading, setInitialLoading] = useState(true);
 
+  const { filters, filteredStreams, setFilter } = useStreamFilter(streams);
+  const wsUrl = import.meta.env.VITE_WS_URL ?? "";
+  const { lastMessage } = useWebSocket<{
+    eventType?: string;
+    type?: string;
+    status?: string;
+    streamId?: string;
+  }>(wsUrl);
 
+  const apiFilters: ListStreamsFilters = useMemo(
+    () => ({
+      status: filters.status,
+      sender: filters.sender,
+      recipient: filters.recipient,
+      asset: filters.assetCode,
+    }),
+    [filters],
+  );
+
+  const tableFilters: ListStreamsFilters = useMemo(
+    () => ({
+      status: filters.status,
+      sender: filters.sender,
+      recipient: filters.recipient,
+      asset: filters.assetCode,
+      q: "",
+    }),
+    [filters],
+  );
 
   const metrics = useMemo(() => {
-    const activeCount = streams.filter(
+    const activeCount = filteredStreams.filter(
       (s) => s.progress.status === "active",
     ).length;
-    const completedCount = streams.filter(
+    const completedCount = filteredStreams.filter(
       (s) => s.progress.status === "completed",
     ).length;
-    const totalVested = streams.reduce(
+    const totalVested = filteredStreams.reduce(
       (sum, s) => sum + s.progress.vestedAmount,
       0,
     );
-
     return {
-      total: streams.length,
+      total: filteredStreams.length,
       active: activeCount,
       completed: completedCount,
       vested: Number(totalVested.toFixed(2)),
     };
-  }, [streams]);
+  }, [filteredStreams]);
 
   const metricsHistory = useMetricsHistory(
     metrics.active,
@@ -91,39 +98,132 @@ function App() {
     5000,
   );
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const rawView = params.get("view");
+    const rawStreamId = params.get("streamId");
+    if (rawView === "dashboard" || rawView === "sender" || rawView === "recipient") {
+      setViewMode(rawView);
+    }
+    setDetailStreamId(rawStreamId);
+  }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (viewMode === "dashboard") {
+      params.delete("view");
+    } else {
+      params.set("view", viewMode);
+    }
+    if (detailStreamId) {
+      params.set("streamId", detailStreamId);
+    } else {
+      params.delete("streamId");
+    }
+    const next = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      next ? `${window.location.pathname}?${next}` : window.location.pathname,
+    );
+  }, [detailStreamId, viewMode]);
+
+  async function refreshStreams(currentFilters: ListStreamsFilters): Promise<void> {
+    const data = await listStreams(currentFilters);
+    setStreams(data);
+  }
+
+  useEffect(() => {
+    setLoadingDashboard(true);
+    refreshStreams(apiFilters)
+      .catch((err: unknown) => {
+        const message =
+          err instanceof ApiError
+            ? `Failed loading streams (${err.statusCode})`
+            : "Failed loading streams";
+        showToast(message, "error");
+      })
+      .finally(() => {
+        setInitialLoading(false);
+        setLoadingDashboard(false);
+      });
+  }, [apiFilters, showToast]);
+
+  useEffect(() => {
+    listOpenIssues()
+      .then(setIssues)
+      .catch(() => undefined);
+  }, []);
+
+  useEffect(() => {
+    if (!lastMessage) return;
+    const eventKind = lastMessage.eventType ?? lastMessage.type ?? "";
+    if (!eventKind) return;
+
+    if (eventKind.includes("created")) {
+      showToast("Stream created", "success");
+    } else if (eventKind.includes("cancel")) {
+      showToast("Stream canceled", "info");
+    } else if (eventKind.includes("complete")) {
+      showToast("Stream completed", "success");
+    }
+    refreshStreams(apiFilters).catch(() => undefined);
+  }, [apiFilters, lastMessage, showToast]);
+
   async function handleCreate(
     payload: Parameters<typeof createStream>[0],
   ): Promise<void> {
     setFormError(null);
-    setGlobalError(null);
     try {
       await createStream(payload);
-      const data = await listStreams(filters);
-      setStreams(data);
+      await refreshStreams(apiFilters);
+      showToast("Stream created successfully", "success");
     } catch (err) {
-      setFormError(
-        err instanceof Error ? err.message : "Failed to create stream.",
-      );
+      if (err instanceof ApiError) {
+        setFormError(err.message);
+        showToast(`Create failed (${err.statusCode}): ${err.message}`, "error");
+        return;
+      }
+      const fallback = err instanceof Error ? err.message : "Failed to create stream.";
+      setFormError(fallback);
+      showToast(fallback, "error");
     }
   }
 
   async function handleCancel(streamId: string): Promise<void> {
-    setGlobalError(null);
-    setFormError(null);
     try {
       await cancelStream(streamId);
-      const data = await listStreams(filters);
-      setStreams(data);
+      await refreshStreams(apiFilters);
+      showToast("Stream canceled", "info");
     } catch (err) {
-      setGlobalError(
-        err instanceof Error
-          ? describeGlobalError(err.message)
-          : "Failed to cancel the stream. Please try again.",
+      if (err instanceof ApiError) {
+        showToast(`Cancel failed (${err.statusCode}): ${err.message}`, "error");
+        return;
+      }
+      showToast(
+        err instanceof Error ? err.message : "Failed to cancel the stream.",
+        "error",
       );
     }
   }
 
+  async function handleUpdateStartTime(streamId: string, nextStartAt: number) {
+    try {
+      await updateStreamStartAt(streamId, nextStartAt);
+      await refreshStreams(apiFilters);
+      showToast("Start time updated", "success");
+    } catch (err) {
+      if (err instanceof ApiError) {
+        showToast(`Update failed (${err.statusCode}): ${err.message}`, "error");
+        return;
+      }
+      showToast("Failed to update stream start time", "error");
+    }
+  }
 
+  if (initialLoading && viewMode === "dashboard") {
+    return <div className="app-shell">Loading dashboard…</div>;
+  }
 
   return (
     <div className="app-shell">
@@ -166,9 +266,11 @@ function App() {
       </nav>
 
       {viewMode === "sender" ? (
-        <SenderDashboard 
-          senderAddress={wallet.address} 
-          onEditStartTime={(stream) => setEditingStream(stream)}
+        <SenderDashboard
+          senderAddress={wallet.address}
+          onEditStartTime={(stream) =>
+            setEditingStream({ stream, triggerRef: { current: null } })
+          }
         />
       ) : viewMode === "recipient" ? (
         <RecipientDashboard recipientAddress={wallet.address} />
@@ -198,35 +300,26 @@ function App() {
             <StreamMetricsChart data={metricsHistory} />
           </section>
 
-          {/* Global (cancel / bootstrap) errors shown as a dismissible banner */}
-          {globalError && (
-            <div className="error-banner" role="alert" aria-live="assertive">
-              <span className="error-banner__icon" aria-hidden>
-                ✕
-              </span>
-              <span>{globalError}</span>
-              <button
-                className="error-banner__dismiss"
-                type="button"
-                aria-label="Dismiss error"
-                onClick={() => setGlobalError(null)}
-              >
-                ×
-              </button>
-            </div>
-          )}
-
           <section className="layout-grid">
-            {/* formError is passed into the form so the create-stream card can show it inline */}
-            <CreateStreamForm onCreate={handleCreate} apiError={formError} />
+            <CreateStreamForm
+              onCreate={handleCreate}
+              apiError={formError}
+              walletAddress={wallet.address}
+            />
             <StreamsTable
-              streams={streams}
-              filters={filters}
-              onFiltersChange={setFilters}
+              streams={filteredStreams}
+              filters={tableFilters}
+              onFiltersChange={(next) => {
+                setFilter("status", next.status ?? defaultStreamFilters.status);
+                setFilter("sender", next.sender ?? defaultStreamFilters.sender);
+                setFilter("recipient", next.recipient ?? defaultStreamFilters.recipient);
+                setFilter("assetCode", next.asset ?? defaultStreamFilters.assetCode);
+              }}
               onCancel={handleCancel}
               onEditStartTime={(stream, triggerRef) =>
                 setEditingStream({ stream, triggerRef })
               }
+              onOpenStream={setDetailStreamId}
             />
           </section>
 
@@ -237,7 +330,6 @@ function App() {
             <StreamTimeline />
           </section>
 
-          {/* Edit start-time modal — only rendered when a stream is being edited */}
           {editingStream && (
             <EditStartTimeModal
               stream={editingStream.stream}
@@ -247,11 +339,10 @@ function App() {
             />
           )}
 
-          {/* Stream detail drawer — URL-driven via ?streamId= */}
           {detailStreamId && (
             <StreamDetailDrawer
               streamId={detailStreamId}
-              onClose={closeStream}
+              onClose={() => setDetailStreamId(null)}
               onCancel={handleCancel}
             />
           )}

--- a/frontend/src/components/StreamsTable.tsx
+++ b/frontend/src/components/StreamsTable.tsx
@@ -1,20 +1,22 @@
-
+import { useMemo, useState, useRef, type RefObject } from "react";
 import { Stream } from "../types/stream";
 import { getExportCsvUrl, ListStreamsFilters } from "../services/api";
 import { CopyableAddress } from "./CopyableAddress";
 import { StreamTimeline } from "./StreamTimeline";
 import { getHealthBadges } from "../utils/streamHealthBadges";
+import { FilterBar } from "./FilterBar";
 
 interface StreamsTableProps {
   streams: Stream[];
   filters: ListStreamsFilters;
   onFiltersChange: (f: ListStreamsFilters) => void;
   onCancel: (streamId: string) => Promise<void>;
+  onOpenStream?: (streamId: string) => void;
   /**
    * Called when the user clicks "Edit" for a scheduled stream.
    * Receives the stream AND the button ref so the modal can return focus.
    */
-  onEditStartTime: (stream: Stream, triggerRef: React.RefObject<HTMLButtonElement | null>) => void;
+  onEditStartTime: (stream: Stream, triggerRef: RefObject<HTMLButtonElement | null>) => void;
 }
 
 function statusClass(status: Stream["progress"]["status"]): string {
@@ -31,9 +33,24 @@ function formatTimestamp(unixSeconds: number): string {
   return new Date(unixSeconds * 1000).toLocaleString();
 }
 
+export function StreamsTable({
+  streams,
+  filters,
+  onFiltersChange,
+  onCancel,
+  onEditStartTime,
+  onOpenStream,
+}: StreamsTableProps) {
+  const [expandedStreamId, setExpandedStreamId] = useState<string | null>(null);
+  const exportUrl = useMemo(() => getExportCsvUrl(filters as Record<string, string>), [filters]);
+
+  const toggleTimeline = (streamId: string) => {
+    setExpandedStreamId((prev) => (prev === streamId ? null : streamId));
+  };
 
   return (
     <div className="card">
+      <FilterBar filters={filters} onChange={onFiltersChange} />
       <div
         style={{
           display: "flex",
@@ -83,6 +100,7 @@ function formatTimestamp(unixSeconds: number): string {
                     onToggleTimeline={toggleTimeline}
                     onCancel={onCancel}
                     onEditStartTime={onEditStartTime}
+                    onOpenStream={onOpenStream}
                   />
                 );
               })}
@@ -108,6 +126,7 @@ interface StreamRowProps {
   onToggleTimeline: (id: string) => void;
   onCancel: (id: string) => Promise<void>;
   onEditStartTime: StreamsTableProps["onEditStartTime"];
+  onOpenStream?: (streamId: string) => void;
 }
 
 function StreamRow({
@@ -119,6 +138,7 @@ function StreamRow({
   onToggleTimeline,
   onCancel,
   onEditStartTime,
+  onOpenStream,
 }: StreamRowProps) {
   /**
    * Stable ref to the "✏️ Edit" button in this row.
@@ -135,7 +155,10 @@ function StreamRow({
             className="btn-ghost"
             aria-expanded={isExpanded}
             aria-controls={`timeline-${stream.id}`}
-            onClick={() => onToggleTimeline(stream.id)}
+            onClick={() => {
+              onToggleTimeline(stream.id);
+              onOpenStream?.(stream.id);
+            }}
             title={isExpanded ? "Hide timeline" : "Show timeline"}
           >
             {isExpanded ? "▲" : "▼"} {stream.id}

--- a/frontend/src/hooks/useStreamFilter.ts
+++ b/frontend/src/hooks/useStreamFilter.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Stream } from "../types/stream";
+
+export interface StreamFilters {
+  status: string;
+  sender: string;
+  recipient: string;
+  assetCode: string;
+}
+
+type FilterKey = keyof StreamFilters;
+
+const EMPTY_FILTERS: StreamFilters = {
+  status: "",
+  sender: "",
+  recipient: "",
+  assetCode: "",
+};
+
+function getFiltersFromUrl(): StreamFilters {
+  const params = new URLSearchParams(window.location.search);
+  return {
+    status: params.get("status") ?? "",
+    sender: params.get("sender") ?? "",
+    recipient: params.get("recipient") ?? "",
+    assetCode: params.get("assetCode") ?? params.get("asset") ?? "",
+  };
+}
+
+function includesCaseInsensitive(value: string, needle: string): boolean {
+  return value.toLowerCase().includes(needle.toLowerCase());
+}
+
+export function useStreamFilter(streams: Stream[]) {
+  const [filters, setFilters] = useState<StreamFilters>(() => getFiltersFromUrl());
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const syncValue = (key: FilterKey) => {
+      const value = filters[key].trim();
+      if (!value) {
+        params.delete(key);
+        if (key === "assetCode") params.delete("asset");
+        return;
+      }
+      params.set(key, value);
+      if (key === "assetCode") params.set("asset", value);
+    };
+
+    syncValue("status");
+    syncValue("sender");
+    syncValue("recipient");
+    syncValue("assetCode");
+
+    const next = params.toString();
+    const nextUrl = next ? `${window.location.pathname}?${next}` : window.location.pathname;
+    window.history.replaceState(null, "", nextUrl);
+  }, [filters]);
+
+  useEffect(() => {
+    const onPopState = () => setFilters(getFiltersFromUrl());
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  const setFilter = useCallback((key: FilterKey, value: string) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const filteredStreams = useMemo(() => {
+    return streams.filter((stream) => {
+      if (filters.status && stream.progress.status !== filters.status) return false;
+      if (filters.sender && !includesCaseInsensitive(stream.sender, filters.sender)) {
+        return false;
+      }
+      if (
+        filters.recipient &&
+        !includesCaseInsensitive(stream.recipient, filters.recipient)
+      ) {
+        return false;
+      }
+      if (
+        filters.assetCode &&
+        !includesCaseInsensitive(stream.assetCode, filters.assetCode)
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [filters, streams]);
+
+  return { filters, setFilter, filteredStreams };
+}
+
+export const defaultStreamFilters = EMPTY_FILTERS;

--- a/frontend/src/hooks/useToast.tsx
+++ b/frontend/src/hooks/useToast.tsx
@@ -1,0 +1,79 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+type ToastType = "success" | "error" | "info";
+
+export interface Toast {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+type ToastContextValue = {
+  toasts: Toast[];
+  showToast: (message: string, type: ToastType) => void;
+  dismissToast: (id: number) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+const AUTO_DISMISS_MS = 4000;
+const MAX_VISIBLE_TOASTS = 3;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const idRef = useRef(1);
+
+  const dismissToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback(
+    (message: string, type: ToastType) => {
+      const id = idRef.current++;
+      setToasts((prev) => [{ id, message, type }, ...prev].slice(0, MAX_VISIBLE_TOASTS));
+      window.setTimeout(() => dismissToast(id), AUTO_DISMISS_MS);
+    },
+    [dismissToast],
+  );
+
+  const value = useMemo(
+    () => ({ toasts, showToast, dismissToast }),
+    [dismissToast, showToast, toasts],
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="toast-stack" aria-live="polite" aria-atomic="true">
+        {toasts.map((toast) => (
+          <div key={toast.id} className={`toast toast--${toast.type}`} role="status">
+            <span>{toast.message}</span>
+            <button
+              type="button"
+              className="toast-dismiss"
+              aria-label="Dismiss notification"
+              onClick={() => dismissToast(toast.id)}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+}

--- a/frontend/src/hooks/useWebSocket.test.ts
+++ b/frontend/src/hooks/useWebSocket.test.ts
@@ -1,0 +1,65 @@
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useWebSocket } from "./useWebSocket";
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(public readonly url: string) {
+    MockWebSocket.instances.push(this);
+    queueMicrotask(() => this.onopen?.());
+  }
+
+  emitMessage(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent<string>);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+describe("useWebSocket", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("reconnects with 1s, 2s, 4s backoff", async () => {
+    renderHook(() => useWebSocket<{ type: string }>("ws://localhost/test"));
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    act(() => {
+      MockWebSocket.instances[0].close();
+      vi.advanceTimersByTime(1000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    act(() => {
+      MockWebSocket.instances[1].close();
+      vi.advanceTimersByTime(2000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(3);
+
+    act(() => {
+      MockWebSocket.instances[2].close();
+      vi.advanceTimersByTime(4000);
+    });
+    expect(MockWebSocket.instances).toHaveLength(4);
+  });
+});

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from "react";
+
+type UseWebSocketResult<T> = {
+  lastMessage: T | null;
+  readyState: number;
+};
+
+const BACKOFF_MS = [1000, 2000, 4000];
+
+export function useWebSocket<T>(url: string): UseWebSocketResult<T> {
+  const [lastMessage, setLastMessage] = useState<T | null>(null);
+  const [readyState, setReadyState] = useState<number>(WebSocket.CLOSED);
+  const reconnectAttemptRef = useRef(0);
+  const reconnectTimerRef = useRef<number | null>(null);
+  const socketRef = useRef<WebSocket | null>(null);
+  const closedByUnmountRef = useRef(false);
+
+  useEffect(() => {
+    if (!url) {
+      setReadyState(WebSocket.CLOSED);
+      return;
+    }
+
+    closedByUnmountRef.current = false;
+
+    const connect = () => {
+      const socket = new WebSocket(url);
+      socketRef.current = socket;
+      setReadyState(socket.readyState);
+
+      socket.onopen = () => {
+        reconnectAttemptRef.current = 0;
+        setReadyState(WebSocket.OPEN);
+      };
+
+      socket.onmessage = (event: MessageEvent<string>) => {
+        try {
+          setLastMessage(JSON.parse(event.data) as T);
+        } catch {
+          // Ignore malformed messages to keep the hook resilient.
+        }
+      };
+
+      socket.onerror = () => {
+        setReadyState(WebSocket.CLOSING);
+      };
+
+      socket.onclose = () => {
+        setReadyState(WebSocket.CLOSED);
+        if (closedByUnmountRef.current) return;
+
+        const attempt = reconnectAttemptRef.current;
+        const backoff =
+          BACKOFF_MS[Math.min(attempt, BACKOFF_MS.length - 1)] ?? BACKOFF_MS[0];
+        reconnectAttemptRef.current += 1;
+        reconnectTimerRef.current = window.setTimeout(connect, backoff);
+      };
+    };
+
+    connect();
+
+    return () => {
+      closedByUnmountRef.current = true;
+      if (reconnectTimerRef.current != null) {
+        window.clearTimeout(reconnectTimerRef.current);
+      }
+      if (socketRef.current) {
+        socketRef.current.close();
+      }
+    };
+  }, [url]);
+
+  return { lastMessage, readyState };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -978,3 +978,51 @@ td {
   color: #0ea5a5;
   border-bottom-color: #0ea5a5;
 }
+
+.toast-stack {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  display: grid;
+  gap: 0.5rem;
+  z-index: 200;
+}
+
+.toast {
+  min-width: 260px;
+  max-width: 360px;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #111827;
+  padding: 0.65rem 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+}
+
+.toast--success {
+  border-color: #86efac;
+  background: #f0fdf4;
+}
+
+.toast--error {
+  border-color: #fca5a5;
+  background: #fef2f2;
+}
+
+.toast--info {
+  border-color: #93c5fd;
+  background: #eff6ff;
+}
+
+.toast-dismiss {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { ToastProvider } from "./hooks/useToast";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ToastProvider>
+      <App />
+    </ToastProvider>
   </React.StrictMode>
 );

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { ApiError, listStreams } from "./api";
+
+describe("api error handling", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws ApiError with statusCode when API returns 400", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "Invalid request" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(listStreams()).rejects.toMatchObject({
+      name: "ApiError",
+      statusCode: 400,
+      message: "Invalid request",
+    });
+  });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -10,17 +10,41 @@ export function getAuthToken(): string | null {
   return authToken;
 }
 
+export class ApiError extends Error {
+  statusCode: number;
+  details?: unknown;
+
+  constructor(message: string, statusCode: number, details?: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
 async function parseResponse<T>(response: Response): Promise<T> {
-  const body = (await response.json().catch(() => ({}))) as T & {
-    error?: string;
-  };
+  const rawBody = await response.text();
+  let body: Record<string, unknown> = {};
+  if (rawBody) {
+    try {
+      body = JSON.parse(rawBody) as Record<string, unknown>;
+    } catch {
+      body = { message: rawBody };
+    }
+  }
+
   if (!response.ok) {
     if (response.status === 401) {
       setAuthToken(null);
     }
-    throw new Error(body.error ?? "Unexpected API error");
+    const message =
+      (body.error as string | undefined) ??
+      (body.message as string | undefined) ??
+      "Unexpected API error";
+    throw new ApiError(message, response.status, body);
   }
-  return body;
+
+  return body as T;
 }
 
 export interface ListStreamsFilters {


### PR DESCRIPTION
## Summary
- add a typed `ApiError` in `frontend/src/services/api.ts` and update API parsing to throw status-aware errors across non-2xx responses
- add `useStreamFilter` (URL-synced filters), `useWebSocket` (auto-reconnect with 1s/2s/4s backoff), and a global `ToastProvider`/`useToast` system with 4s auto-dismiss and max 3 stacked toasts
- refactor `App.tsx` and `StreamsTable.tsx` to use these hooks, replace global error banner with toasts, and add tests for API 400 handling and websocket reconnect behavior

## Test plan
- [x] `npm --prefix frontend run test -- --run src/services/api.test.ts src/hooks/useWebSocket.test.ts`
- [ ] Run full frontend test suite (currently blocked by pre-existing missing modules in unrelated recipient dashboard files)

Closes #161
Closes #167
Closes #168
Closes #169

