### PR TITLE
Add Docker healthchecks to docker-compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
       - "3001:3001"
     env_file:
       - ./backend/.env
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3001/api/health"]
+      interval: 10s
+      retries: 3
     restart: unless-stopped
 
   frontend:
@@ -20,5 +24,10 @@ services:
     environment:
       - VITE_API_URL=http://backend:3001/api
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 3000 || exit 1"]
+      interval: 10s
+      retries: 3
     restart: unless-stopped


### PR DESCRIPTION
Close: #171 
I have added the requested Docker healthchecks to your docker-compose.yml file.

Here is what was changed:

Backend Healthcheck: Added a curl test for http://localhost:3001/api/health with a 10s interval and 3 retries.
Frontend Healthcheck: Added a TCP port check (nc -z localhost 3000) with a 10s interval and 3 retries.
Dependencies: Updated the frontend's depends_on setting to use the condition: service_healthy check for the backend, ensuring it waits for the backend API to be ready before starting.