### PR TITLE
Add e2e-smoke job for health check validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,74 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: npm run build
+
+  backend-test:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Run backend tests
+        working-directory: backend
+        run: npm test
+
+  e2e-smoke:
+    name: E2E Smoke Test
+    runs-on: ubuntu-latest
+    needs: backend-test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Copy env file
+        run: cp backend/.env.example backend/.env
+
+      - name: Start Docker Compose
+        run: docker compose up -d
+
+      - name: Wait for service to be healthy
+        run: |
+          timeout=60
+          while [ $timeout -gt 0 ]; do
+            if curl -f -s http://localhost:3001/api/health > /dev/null; then
+              break
+            fi
+            sleep 2
+            timeout=$((timeout - 2))
+          done
+          if [ $timeout -le 0 ]; then
+            echo "Service did not start within timeout"
+            docker compose logs
+            exit 1
+          fi
+
+      - name: Install jq
+        run: apt-get update && apt-get install -y jq
+
+      - name: Assert health response
+        run: |
+          response=$(curl -s http://localhost:3001/api/health)
+          if echo "$response" | jq -e '.status == "ok"' > /dev/null 2>&1; then
+            echo "Health check passed: $response"
+          else
+            echo "Health check failed: $response"
+            exit 1
+          fi
+
+      - name: Tear down
+        run: docker compose down
+        if: always()


### PR DESCRIPTION
- Add backend-test job to run unit tests
- Add e2e-smoke job that runs after backend-test succeeds
- Smoke test starts Docker Compose stack, waits for health endpoint, asserts 200 and status: 'ok', then tears down

Wave 4 theme: CI/CD reliability
close #172