### PR TITLE
feat(events): [wave4] record StreamClaimed events in event history

### DIFF
--- a/backend/src/services/indexer.test.ts
+++ b/backend/src/services/indexer.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for indexer processEvent — verifies StreamClaimed events
+ * are correctly parsed and recorded into event_history.
+ * Issue #144: Record claimed events when contract emits StreamClaimed
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+
+// ── Stub metrics ──────────────────────────────────────────────────────────
+vi.mock("./metrics", () => ({
+  eventsIndexedTotal:  { inc: vi.fn() },
+  ledgersScannedTotal: { inc: vi.fn() },
+  lastIndexedLedger:   { set: vi.fn() },
+  indexerErrorsTotal:  { inc: vi.fn() },
+  indexerCircuitState: { set: vi.fn() },
+}));
+
+// ── In-memory DB ──────────────────────────────────────────────────────────
+let db: InstanceType<typeof Database>;
+vi.mock("./db", () => ({ getDb: () => db }));
+
+// ── Spy on recordEventWithDb ──────────────────────────────────────────────
+const recordEventWithDb = vi.fn();
+vi.mock("./eventHistory", () => ({ recordEventWithDb }));
+
+// ── Mock rpc.Server at module level ──────────────────────────────────────
+let mockGetLatestLedger = vi.fn();
+let mockGetEvents = vi.fn();
+
+vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@stellar/stellar-sdk")>();
+  return {
+    ...actual,
+    // scValToNative is called on topic items and event.value in processEvent.
+    // In tests we pass already-decoded plain JS values, so identity is correct.
+    scValToNative: (v: any) => v,
+    rpc: {
+      ...actual.rpc,
+      Server: vi.fn().mockImplementation(() => ({
+        getLatestLedger: mockGetLatestLedger,
+        getEvents: mockGetEvents,
+      })),
+    },
+  };
+});
+
+// Import after all mocks are registered
+const { initIndexer, startIndexer, stopIndexer } = await import("./indexer");
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function makeClaimedEvent(opts: {
+  streamId?: string | number;
+  recipient?: string;
+  amount?: number;
+  ledgerClosedAt?: string;
+} = {}) {
+  const {
+    streamId = "42",
+    recipient = "GRECIPI1234567890123456789012345678901234567890123456",
+    amount = 500,
+    ledgerClosedAt = new Date(1_700_000_000_000).toISOString(),
+  } = opts;
+  return {
+    topic: ["Stream", "Claimed"],
+    value: { stream_id: BigInt(streamId), recipient, amount: BigInt(amount) },
+    ledgerClosedAt,
+  };
+}
+
+function makeCreatedEvent() {
+  return {
+    topic: ["Stream", "Created"],
+    value: {
+      stream_id: BigInt(1),
+      sender: "GSENDER1234567890123456789012345678901234567890123456",
+      recipient: "GRECIPI1234567890123456789012345678901234567890123456",
+      token: "GTOKEN12345678901234567890123456789012345678901234567",
+      total_amount: BigInt(1000),
+      start_time: BigInt(0),
+      end_time: BigInt(1000),
+    },
+    ledgerClosedAt: new Date(1_700_000_000_000).toISOString(),
+  };
+}
+
+// Use a unique contract ID per test to avoid module-level lastProcessedLedger state bleed
+let testContractCounter = 0;
+function nextContractId() {
+  return `CONTRACT${String(++testContractCounter).padStart(3, "0")}`;
+}
+
+function setupDb(contractId: string, lastLedger = 100) {
+  db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE stream_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      stream_id TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      timestamp INTEGER NOT NULL,
+      actor TEXT,
+      amount REAL,
+      metadata TEXT
+    );
+    CREATE TABLE indexer_cursor (
+      id TEXT PRIMARY KEY,
+      last_ledger INTEGER NOT NULL
+    );
+  `);
+  db.prepare("INSERT INTO indexer_cursor (id, last_ledger) VALUES (?, ?)").run(contractId, lastLedger);
+}
+
+async function runOnePoll(contractId: string) {
+  initIndexer("https://rpc.example.com", contractId, "Test SDF Network ; September 2015");
+  await new Promise<void>((resolve) => {
+    startIndexer(50);
+    setTimeout(() => { stopIndexer(); resolve(); }, 150);
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+describe("indexer processEvent — StreamClaimed", () => {
+  let ledgerSeq = 200;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ledgerSeq += 200; // always higher than any previous lastProcessedLedger
+    mockGetLatestLedger.mockResolvedValue({ sequence: ledgerSeq });
+  });
+
+  it("calls recordEventWithDb with type='claimed', recipient as actor, and amount", async () => {
+    const cid = nextContractId();
+    setupDb(cid, ledgerSeq - 100);
+    const event = makeClaimedEvent({ streamId: "7", recipient: "GRECIPI1234567890123456789012345678901234567890123456", amount: 250 });
+    mockGetEvents.mockResolvedValue({ events: [event] });
+
+    await runOnePoll(cid);
+
+    expect(recordEventWithDb).toHaveBeenCalledWith(
+      expect.anything(),
+      "7",
+      "claimed",
+      Math.floor(new Date(event.ledgerClosedAt).getTime() / 1000),
+      event.value.recipient,
+      event.value.amount,
+    );
+  });
+
+  it("records claimed event after created event in the same poll", async () => {
+    const cid = nextContractId();
+    setupDb(cid, ledgerSeq - 100);
+    const created = makeCreatedEvent();
+    const claimed = makeClaimedEvent({ streamId: "1", amount: 300 });
+    mockGetEvents.mockResolvedValue({ events: [created, claimed] });
+
+    await runOnePoll(cid);
+
+    const calls = recordEventWithDb.mock.calls;
+    const createdCall = calls.find((c: any[]) => c[2] === "created");
+    const claimedCall = calls.find((c: any[]) => c[2] === "claimed");
+
+    expect(createdCall).toBeDefined();
+    expect(claimedCall).toBeDefined();
+    expect(claimedCall[4]).toBe(claimed.value.recipient);
+    expect(claimedCall[5]).toBe(claimed.value.amount);
+  });
+
+  it("does not call recordEventWithDb for a malformed Claimed event (null value)", async () => {
+    const cid = nextContractId();
+    setupDb(cid, ledgerSeq - 100);
+    const badEvent = {
+      topic: ["Stream", "Claimed"],
+      value: null,
+      ledgerClosedAt: new Date().toISOString(),
+    };
+    mockGetEvents.mockResolvedValue({ events: [badEvent] });
+
+    await runOnePoll(cid);
+
+    const claimedCall = recordEventWithDb.mock.calls.find((c: any[]) => c[2] === "claimed");
+    expect(claimedCall).toBeUndefined();
+  });
+
+  it("records multiple claimed events from the same poll in order", async () => {
+    const cid = nextContractId();
+    setupDb(cid, ledgerSeq - 100);
+    const claim1 = makeClaimedEvent({ streamId: "1", amount: 100, ledgerClosedAt: new Date(1_700_000_000_000).toISOString() });
+    const claim2 = makeClaimedEvent({ streamId: "1", amount: 200, ledgerClosedAt: new Date(1_700_001_000_000).toISOString() });
+    mockGetEvents.mockResolvedValue({ events: [claim1, claim2] });
+
+    await runOnePoll(cid);
+
+    const claimedCalls = recordEventWithDb.mock.calls.filter((c: any[]) => c[2] === "claimed");
+    expect(claimedCalls).toHaveLength(2);
+    expect(claimedCalls[0][5]).toBe(claim1.value.amount);
+    expect(claimedCalls[1][5]).toBe(claim2.value.amount);
+  });
+});


### PR DESCRIPTION
Closes #144

Summary

Wires up StreamClaimed contract events so claim transactions appear in the stream timeline. Part of Wave 4 — Event completeness.

Background

The contract emits (symbol_short!("Stream"), symbol_short!("Claimed")) with a StreamClaimed { stream_id, recipient, amount } payload. The indexer's processEvent switch already had the "Claimed" case but had no test coverage to prove it worked. This PR locks that in.

Changes

indexer.test.ts
 (new) 4 tests driving the indexer through a mock rpc.Server to verify the full StreamClaimed pipeline:

recordEventWithDb is called with type='claimed', recipient as actor, and amount populated
claimed event is recorded correctly alongside a created event in the same poll
malformed/null event value is handled gracefully — no record written, no crash
multiple claimed events in one poll are recorded in order
No production code changes were needed — the backend pipeline, API endpoint, and frontend StreamTimeline were already correct:

indexer.ts — "Claimed" case already calls recordEventWithDb with the right args
GET /api/streams/:id/history — already returns all event types ordered by timestamp ASC
StreamTimeline.tsx — already renders claimed events with amount label ("Claim of X tokens processed by ...")
Testing

./node_modules/.bin/vitest run src/services/indexer.test.ts
All 4 pass. The "Failed to process event" stderr in test 3 is intentional — it's the catch block in processEvent handling the malformed null input correctly.