### PR TITLE
Implement Wave 4 assigned stream enhancements

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -2,6 +2,7 @@
 
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, token::Client as TokenClient, Address, Env,
+    String, Vec,
 };
 
 #[contracttype]
@@ -15,12 +16,16 @@ pub struct Stream {
     pub start_time: u64,
     pub end_time: u64,
     pub canceled: bool,
+    pub paused: bool,
+    pub pause_started_at: Option<u64>,
 }
 
 #[contracttype]
 enum DataKey {
     NextStreamId,
     Stream(u64),
+    SplitChildren(u64),
+    ChildToParent(u64),
 }
 
 #[contracttype]
@@ -30,6 +35,7 @@ pub struct StreamCreated {
     pub sender: Address,
     pub recipient: Address,
     pub token: Address,
+    pub token_symbol: String,
     pub total_amount: i128,
     pub start_time: u64,
     pub end_time: u64,
@@ -100,6 +106,8 @@ impl StellarStreamContract {
             start_time,
             end_time,
             canceled: false,
+            paused: false,
+            pause_started_at: None,
         };
 
         env.storage()
@@ -115,7 +123,8 @@ impl StellarStreamContract {
                 stream_id: next_id,
                 sender,
                 recipient,
-                token,
+                token: token.clone(),
+                token_symbol: token_client.symbol(),
                 total_amount,
                 start_time,
                 end_time,
@@ -123,6 +132,109 @@ impl StellarStreamContract {
         );
 
         next_id
+    }
+
+    pub fn create_split_stream(
+        env: Env,
+        sender: Address,
+        token: Address,
+        total_amount: i128,
+        start_time: u64,
+        end_time: u64,
+        recipients: Vec<(Address, i128)>,
+    ) -> u64 {
+        sender.require_auth();
+        if total_amount <= 0 {
+            panic!("total_amount must be positive");
+        }
+        if end_time <= start_time {
+            panic!("end_time must be greater than start_time");
+        }
+        if recipients.is_empty() {
+            panic!("recipients must not be empty");
+        }
+
+        let token_client = TokenClient::new(&env, &token);
+        let sender_balance = token_client.balance(&sender);
+        if sender_balance < total_amount {
+            panic!("insufficient sender balance");
+        }
+        let contract_address = env.current_contract_address();
+        token_client.transfer(&sender, &contract_address, &total_amount);
+
+        let mut next_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NextStreamId)
+            .unwrap_or(0);
+        let parent_stream_id = next_id + 1;
+        next_id = parent_stream_id;
+
+        let mut allocated_total = 0_i128;
+        let mut child_ids = Vec::<u64>::new(&env);
+        for recipient_allocation in recipients.iter() {
+            let recipient = recipient_allocation.0.clone();
+            let allocation = recipient_allocation.1;
+            if allocation <= 0 {
+                panic!("allocation must be positive");
+            }
+            allocated_total += allocation;
+
+            next_id += 1;
+            let child_stream_id = next_id;
+            let child_stream = Stream {
+                sender: sender.clone(),
+                recipient: recipient.clone(),
+                token: token.clone(),
+                total_amount: allocation,
+                claimed_amount: 0,
+                start_time,
+                end_time,
+                canceled: false,
+                paused: false,
+                pause_started_at: None,
+            };
+            env.storage()
+                .persistent()
+                .set(&DataKey::Stream(child_stream_id), &child_stream);
+            env.storage()
+                .persistent()
+                .set(&DataKey::ChildToParent(child_stream_id), &parent_stream_id);
+            child_ids.push_back(child_stream_id);
+
+            env.events().publish(
+                (symbol_short!("Stream"), symbol_short!("Created")),
+                StreamCreated {
+                    stream_id: child_stream_id,
+                    sender: sender.clone(),
+                    recipient,
+                    token: token.clone(),
+                    token_symbol: token_client.symbol(),
+                    total_amount: allocation,
+                    start_time,
+                    end_time,
+                },
+            );
+        }
+
+        if allocated_total != total_amount {
+            panic!("allocations must equal total_amount");
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::SplitChildren(parent_stream_id), &child_ids);
+        env.storage()
+            .persistent()
+            .set(&DataKey::NextStreamId, &next_id);
+        parent_stream_id
+    }
+
+    pub fn get_split_children(env: Env, parent_stream_id: u64) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SplitChildren(parent_stream_id))
+            .unwrap_or_else(|| Vec::<u64>::new(&env))
     }
 
     pub fn get_stream(env: Env, stream_id: u64) -> Stream {
@@ -235,6 +347,51 @@ impl StellarStreamContract {
             StreamCanceled { stream_id, sender },
         );
     }
+
+    pub fn pause_stream(env: Env, stream_id: u64, sender: Address) {
+        let mut stream = read_stream(&env, stream_id);
+        if stream.sender != sender {
+            panic!("sender mismatch");
+        }
+        sender.require_auth();
+        if stream.canceled {
+            panic!("stream canceled");
+        }
+        if stream.paused {
+            panic!("stream already paused");
+        }
+
+        stream.paused = true;
+        stream.pause_started_at = Some(env.ledger().timestamp());
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stream(stream_id), &stream);
+    }
+
+    pub fn resume_stream(env: Env, stream_id: u64, sender: Address) {
+        let mut stream = read_stream(&env, stream_id);
+        if stream.sender != sender {
+            panic!("sender mismatch");
+        }
+        sender.require_auth();
+        if !stream.paused {
+            panic!("stream is not paused");
+        }
+
+        let pause_started_at = stream
+            .pause_started_at
+            .unwrap_or_else(|| panic!("pause timestamp missing"));
+        let now = env.ledger().timestamp();
+        let paused_duration = now.saturating_sub(pause_started_at);
+        stream.start_time = stream.start_time.saturating_add(paused_duration);
+        stream.end_time = stream.end_time.saturating_add(paused_duration);
+        stream.paused = false;
+        stream.pause_started_at = None;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stream(stream_id), &stream);
+    }
 }
 
 fn read_stream(env: &Env, stream_id: u64) -> Stream {
@@ -245,14 +402,23 @@ fn read_stream(env: &Env, stream_id: u64) -> Stream {
 }
 
 fn vested_amount(stream: &Stream, at_time: u64) -> i128 {
-    if at_time <= stream.start_time {
+    let mut effective_at_time = at_time;
+    if stream.paused {
+        if let Some(paused_at) = stream.pause_started_at {
+            if effective_at_time > paused_at {
+                effective_at_time = paused_at;
+            }
+        }
+    }
+
+    if effective_at_time <= stream.start_time {
         return 0;
     }
 
-    let effective_time = if at_time >= stream.end_time {
+    let effective_time = if effective_at_time >= stream.end_time {
         stream.end_time
     } else {
-        at_time
+        effective_at_time
     };
 
     let elapsed = effective_time - stream.start_time;

--- a/contracts/src/snapshots/stellar_stream__test__stream_created_event.snap
+++ b/contracts/src/snapshots/stellar_stream__test__stream_created_event.snap
@@ -1,0 +1,15 @@
+---
+source: src/test.rs
+assertion_line: 483
+expression: event
+---
+StreamCreated {
+    stream_id: 1,
+    sender: Contract(CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM),
+    recipient: Contract(CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4),
+    token: Contract(CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M),
+    token_symbol: String(TEST),
+    total_amount: 1000,
+    start_time: 100,
+    end_time: 200,
+}

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -3,7 +3,7 @@ extern crate std;
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
-    token, Address, Env, IntoVal, symbol_short,
+    token, Address, Env, IntoVal, Vec, symbol_short,
 };
 use insta::assert_debug_snapshot as assert_snapshot;
 
@@ -408,6 +408,7 @@ fn test_event_emissions() {
     );
 
     let event_data: StreamCreated = last_event.2.into_val(&env);
+    let expected_symbol = token::Client::new(&env, &token).symbol();
     assert_eq!(
         event_data,
         StreamCreated {
@@ -415,6 +416,7 @@ fn test_event_emissions() {
             sender: sender.clone(),
             recipient: recipient.clone(),
             token: token.clone(),
+            token_symbol: expected_symbol,
             total_amount: 1000,
             start_time: 0,
             end_time: 1000,
@@ -472,12 +474,142 @@ fn test_stream_created_snapshot() {
         sender: sender.clone(),
         recipient: recipient.clone(),
         token: token.clone(),
+        token_symbol: soroban_sdk::String::from_str(&env, "TEST"),
         total_amount: 1000,
         start_time: 100,
         end_time: 200,
     };
     
     assert_snapshot!("stream_created_event", event);
+}
+
+#[test]
+fn test_create_split_stream_creates_child_streams_and_links() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient_a = Address::generate(&env);
+    let recipient_b = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    let mut recipients = Vec::new(&env);
+    recipients.push_back((recipient_a.clone(), 400));
+    recipients.push_back((recipient_b.clone(), 600));
+
+    let parent_id = client.create_split_stream(&sender, &token, &1000, &0, &1000, &recipients);
+    let children = client.get_split_children(&parent_id);
+
+    assert_eq!(children.len(), 2);
+    let child_a_id = children.get(0).unwrap();
+    let child_b_id = children.get(1).unwrap();
+
+    let child_a = client.get_stream(&child_a_id);
+    let child_b = client.get_stream(&child_b_id);
+    assert_eq!(child_a.recipient, recipient_a);
+    assert_eq!(child_a.total_amount, 400);
+    assert_eq!(child_b.recipient, recipient_b);
+    assert_eq!(child_b.total_amount, 600);
+}
+
+#[test]
+fn test_split_stream_claim_and_cancel_work_per_substream() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient_a = Address::generate(&env);
+    let recipient_b = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+    let token_client = token::Client::new(&env, &token);
+
+    let mut recipients = Vec::new(&env);
+    recipients.push_back((recipient_a.clone(), 400));
+    recipients.push_back((recipient_b.clone(), 600));
+
+    let parent_id = client.create_split_stream(&sender, &token, &1000, &0, &1000, &recipients);
+    let children = client.get_split_children(&parent_id);
+    let child_a_id = children.get(0).unwrap();
+    let child_b_id = children.get(1).unwrap();
+
+    env.ledger().with_mut(|l| l.timestamp = 500);
+    client.claim(&child_a_id, &recipient_a, &200);
+    client.cancel(&child_b_id, &sender);
+
+    assert_eq!(token_client.balance(&recipient_a), 200);
+    assert_eq!(token_client.balance(&sender), 300);
+    assert_eq!(client.claimable(&child_b_id, &1000), 300);
+}
+
+#[test]
+fn test_pause_resume_freezes_vesting_and_extends_end_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000);
+    env.ledger().with_mut(|l| l.timestamp = 300);
+    client.pause_stream(&stream_id, &sender);
+    assert_eq!(client.claimable(&stream_id, &450), 300);
+
+    env.ledger().with_mut(|l| l.timestamp = 500);
+    client.resume_stream(&stream_id, &sender);
+
+    assert_eq!(client.claimable(&stream_id, &700), 500);
+    assert_eq!(client.claimable(&stream_id, &1200), 1000);
+}
+
+#[test]
+fn test_vested_amount_fuzz_invariants() {
+    let env = Env::default();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let stream = Stream {
+        sender,
+        recipient,
+        token,
+        total_amount: 1_000_000,
+        claimed_amount: 0,
+        start_time: 100,
+        end_time: 10_100,
+        canceled: false,
+        paused: false,
+        pause_started_at: None,
+    };
+
+    let mut seed: u64 = 0xDEADBEEFCAFEBABE;
+    for _ in 0..2048 {
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let at_time = seed % 20_000;
+        let vested = vested_amount(&stream, at_time);
+        assert!(vested <= stream.total_amount);
+        assert!(vested >= 0);
+        if at_time <= stream.start_time {
+            assert_eq!(vested, 0);
+        }
+        if at_time >= stream.end_time {
+            assert_eq!(vested, stream.total_amount);
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- implement `create_split_stream` with per-recipient child streams and parent->children linkage in storage
- add stream pause/resume state handling so vesting freezes while paused and timing extends on resume
- emit `token_symbol` in `StreamCreated` events and extend contract tests with split-stream, pause/resume, and vested amount fuzz invariants

## Test plan
- [x] `cd contracts && cargo test`

Closes #118
Closes #123
Closes #126
Closes #127



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Split-stream creation now allows distributing a single stream across multiple recipients with individual allocations.
  * Pause and resume functionality for streams, with automatic time-period adjustments upon resumption.
  * Enhanced event transparency with token symbol information included in stream notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->