### PR TITLE
Add contract and backend tests for issues #214, #213, #218, #220

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1073,7 +1073,6 @@
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2203,7 +2202,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4429,7 +4427,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,12 +12,12 @@
   "dependencies": {
     "@stellar/stellar-sdk": "^14.5.0",
     "axios": "^1.13.5",
-    "p-limit": "^4.0.0",
     "better-sqlite3": "^12.6.2",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",
+    "p-limit": "^4.0.0",
     "swagger-ui-express": "^5.0.1",
     "ws": "^8.14.2",
     "zod": "^4.3.6"

--- a/backend/src/services/streamStore.reconcile.test.ts
+++ b/backend/src/services/streamStore.reconcile.test.ts
@@ -1,0 +1,368 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Shared mock state
+// ---------------------------------------------------------------------------
+
+type StoredStream = {
+  id: string;
+  sender: string;
+  recipient: string;
+  assetCode: string;
+  totalAmount: number;
+  durationSeconds: number;
+  startAt: number;
+  createdAt: number;
+  canceledAt?: number | null;
+  completedAt?: number | null;
+};
+
+const mockState = vi.hoisted(() => ({
+  nextId: 1,
+  existingStreamIds: new Set<string>(),
+  chainStreams: new Map<number, any>(),
+  upsertedStreams: [] as StoredStream[],
+  createdEventIds: new Set<string>(),
+  simulateTimeout: false,
+}));
+
+const dbMocks = vi.hoisted(() => ({
+  initDb: vi.fn(),
+  getDb: vi.fn(),
+}));
+
+const eventHistoryMocks = vi.hoisted(() => ({
+  recordEventWithDb: vi.fn(),
+  streamHasEvent: vi.fn((streamId: string, eventType: string) => {
+    return eventType === "created" && mockState.createdEventIds.has(streamId);
+  }),
+}));
+
+vi.mock("./db", () => dbMocks);
+vi.mock("./eventHistory", () => eventHistoryMocks);
+vi.mock("./webhook", () => ({ triggerWebhook: vi.fn() }));
+
+vi.mock("@stellar/stellar-sdk", () => {
+  class MockContract {
+    contractId: string;
+    constructor(contractId: string) {
+      this.contractId = contractId;
+    }
+    call(method: string, ...args: any[]) {
+      return { method, args };
+    }
+  }
+
+  class MockTransactionBuilder {
+    private operation: any;
+    constructor(_sourceAccount: any, _options: any) {}
+    addOperation(operation: any) {
+      this.operation = operation;
+      return this;
+    }
+    setTimeout(_timeout: number) {
+      return this;
+    }
+    build() {
+      return { operation: this.operation };
+    }
+  }
+
+  class MockServer {
+    constructor(_rpcUrl: string) {}
+
+    async getAccount(_pubKey: string) {
+      return { accountId: "mock-account" };
+    }
+
+    async simulateTransaction(tx: any) {
+      if (mockState.simulateTimeout) {
+        throw new Error("timeout: RPC server did not respond");
+      }
+
+      const operation = tx.operation;
+      if (operation.method === "get_next_stream_id") {
+        return { kind: "success", result: { retval: mockState.nextId } };
+      }
+
+      if (operation.method === "get_stream") {
+        const streamId = Number(operation.args[0]);
+        const chainStream = mockState.chainStreams.get(streamId);
+        if (!chainStream) {
+          return { kind: "error" };
+        }
+        return { kind: "success", result: { retval: chainStream } };
+      }
+
+      throw new Error(`Unexpected contract method: ${operation.method}`);
+    }
+  }
+
+  return {
+    Keypair: { fromSecret: vi.fn() },
+    rpc: {
+      Server: MockServer,
+      Api: { isSimulationSuccess: (response: any) => response.kind === "success" },
+    },
+    Contract: MockContract,
+    nativeToScVal: (value: any) => value,
+    scValToNative: (value: any) => value,
+    Address: class MockAddress {},
+    TimeoutInfinite: {},
+    TransactionBuilder: MockTransactionBuilder,
+    Networks: { TESTNET: "TESTNET" },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// DB mock factory
+// ---------------------------------------------------------------------------
+
+function createDbMock() {
+  return {
+    prepare(sql: string) {
+      if (sql.includes("SELECT id FROM streams")) {
+        return {
+          all: () =>
+            Array.from(mockState.existingStreamIds).map((id) => ({ id })),
+        };
+      }
+
+      if (sql.includes("INSERT INTO streams")) {
+        return {
+          run: (params: any) => {
+            mockState.existingStreamIds.add(params.id);
+            mockState.upsertedStreams.push({
+              id: params.id,
+              sender: params.sender,
+              recipient: params.recipient,
+              assetCode: params.assetCode,
+              totalAmount: params.totalAmount,
+              durationSeconds: params.durationSeconds,
+              startAt: params.startAt,
+              createdAt: params.createdAt,
+              canceledAt: params.canceledAt,
+              completedAt: params.completedAt,
+            });
+            return { changes: 1 };
+          },
+        };
+      }
+
+      throw new Error(`Unexpected SQL: ${sql}`);
+    },
+    transaction<T extends (...args: any[]) => any>(callback: T): T {
+      return ((...args: Parameters<T>) => callback(...args)) as T;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("reconcileMissingStreams – sync correctness", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockState.nextId = 1;
+    mockState.existingStreamIds = new Set<string>();
+    mockState.chainStreams = new Map<number, any>();
+    mockState.upsertedStreams = [];
+    mockState.createdEventIds = new Set<string>();
+    mockState.simulateTimeout = false;
+
+    dbMocks.getDb.mockReturnValue(createDbMock());
+    dbMocks.initDb.mockImplementation(() => undefined);
+
+    process.env.CONTRACT_ID = "test-contract";
+    process.env.RPC_URL = "https://rpc.test";
+    delete process.env.SERVER_PRIVATE_KEY;
+  });
+
+  it("inserts on-chain streams that are missing from local SQLite with correct field mapping", async () => {
+    mockState.nextId = 3;
+    mockState.chainStreams.set(1, {
+      sender: "GSENDER1",
+      recipient: "GRECIPIENT1",
+      token: "USDC",
+      total_amount: 500,
+      start_time: 200,
+      end_time: 800,
+      canceled: false,
+    });
+    mockState.chainStreams.set(2, {
+      sender: "GSENDER2",
+      recipient: "GRECIPIENT2",
+      token: "XLM",
+      total_amount: 1000,
+      start_time: 300,
+      end_time: 900,
+      canceled: false,
+    });
+
+    const { initSoroban, reconcileMissingStreams } = await import("./streamStore");
+    await initSoroban();
+    const repaired = await reconcileMissingStreams();
+
+    expect(repaired).toBe(2);
+    expect(mockState.upsertedStreams).toHaveLength(2);
+
+    expect(mockState.upsertedStreams[0]).toMatchObject({
+      id: "1",
+      sender: "GSENDER1",
+      recipient: "GRECIPIENT1",
+      assetCode: "USDC",
+      totalAmount: 500,
+      durationSeconds: 600, // 800 - 200
+      startAt: 200,
+    });
+
+    expect(mockState.upsertedStreams[1]).toMatchObject({
+      id: "2",
+      sender: "GSENDER2",
+      recipient: "GRECIPIENT2",
+      assetCode: "XLM",
+      totalAmount: 1000,
+      durationSeconds: 600, // 900 - 300
+      startAt: 300,
+    });
+
+    // Created events must be recorded for both
+    expect(eventHistoryMocks.recordEventWithDb).toHaveBeenCalledTimes(2);
+    expect(eventHistoryMocks.recordEventWithDb).toHaveBeenCalledWith(
+      expect.anything(),
+      "1",
+      "created",
+      200,
+      "GSENDER1",
+      500,
+      expect.objectContaining({ source: "reconciliation" }),
+    );
+    expect(eventHistoryMocks.recordEventWithDb).toHaveBeenCalledWith(
+      expect.anything(),
+      "2",
+      "created",
+      300,
+      "GSENDER2",
+      1000,
+      expect.objectContaining({ source: "reconciliation" }),
+    );
+  });
+
+  it("does not duplicate rows for streams already present in local DB", async () => {
+    mockState.nextId = 3;
+    // Both streams already exist locally
+    mockState.existingStreamIds = new Set(["1", "2"]);
+    mockState.createdEventIds = new Set(["1", "2"]);
+    mockState.chainStreams.set(1, {
+      sender: "GSENDER1",
+      recipient: "GRECIPIENT1",
+      token: "USDC",
+      total_amount: 100,
+      start_time: 10,
+      end_time: 20,
+      canceled: false,
+    });
+    mockState.chainStreams.set(2, {
+      sender: "GSENDER2",
+      recipient: "GRECIPIENT2",
+      token: "USDC",
+      total_amount: 200,
+      start_time: 30,
+      end_time: 50,
+      canceled: false,
+    });
+
+    const { initSoroban, reconcileMissingStreams } = await import("./streamStore");
+    await initSoroban();
+    const repaired = await reconcileMissingStreams();
+
+    // Nothing to repair — no upserts, no events
+    expect(repaired).toBe(0);
+    expect(mockState.upsertedStreams).toHaveLength(0);
+    expect(eventHistoryMocks.recordEventWithDb).not.toHaveBeenCalled();
+  });
+
+  it("only backfills the missing stream when some are present and some are not", async () => {
+    mockState.nextId = 4;
+    mockState.existingStreamIds = new Set(["1", "3"]);
+    mockState.chainStreams.set(2, {
+      sender: "GSENDER2",
+      recipient: "GRECIPIENT2",
+      token: "USDC",
+      total_amount: 250,
+      start_time: 100,
+      end_time: 160,
+      canceled: false,
+    });
+
+    const { initSoroban, reconcileMissingStreams } = await import("./streamStore");
+    await initSoroban();
+    const repaired = await reconcileMissingStreams();
+
+    expect(repaired).toBe(1);
+    expect(mockState.upsertedStreams).toHaveLength(1);
+    expect(mockState.upsertedStreams[0].id).toBe("2");
+
+    // Row count: only 1 new row inserted
+    expect(eventHistoryMocks.recordEventWithDb).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not crash when RPC times out — logs error and returns 0", async () => {
+    mockState.nextId = 3;
+    mockState.existingStreamIds = new Set(["1"]);
+    // Trigger timeout on all RPC calls
+    mockState.simulateTimeout = true;
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const { initSoroban, reconcileMissingStreams } = await import("./streamStore");
+    await initSoroban();
+    const repaired = await reconcileMissingStreams();
+
+    // Reconciliation must not throw — returns 0 and logs the error
+    expect(repaired).toBe(0);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(mockState.upsertedStreams).toHaveLength(0);
+
+    errorSpy.mockRestore();
+  });
+
+  it("is idempotent — running twice does not duplicate rows or events", async () => {
+    mockState.nextId = 3;
+    mockState.chainStreams.set(1, {
+      sender: "GSENDER1",
+      recipient: "GRECIPIENT1",
+      token: "USDC",
+      total_amount: 100,
+      start_time: 10,
+      end_time: 20,
+      canceled: false,
+    });
+    mockState.chainStreams.set(2, {
+      sender: "GSENDER2",
+      recipient: "GRECIPIENT2",
+      token: "USDC",
+      total_amount: 200,
+      start_time: 30,
+      end_time: 50,
+      canceled: false,
+    });
+
+    const { initSoroban, reconcileMissingStreams } = await import("./streamStore");
+    await initSoroban();
+
+    const firstRun = await reconcileMissingStreams();
+    // Simulate events now recorded after first run
+    mockState.createdEventIds = new Set(["1", "2"]);
+    const secondRun = await reconcileMissingStreams();
+
+    expect(firstRun).toBe(2);
+    expect(secondRun).toBe(0);
+    // Upsert is called twice on second run (upsert is idempotent by design via ON CONFLICT)
+    // but recordEventWithDb must only be called for the first run
+    expect(eventHistoryMocks.recordEventWithDb).toHaveBeenCalledTimes(2);
+  });
+});

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -58,6 +58,7 @@ pub struct StreamCreated {
     pub start_time: u64,
     pub end_time: u64,
     pub cliff_seconds: u64,
+    pub metadata: Option<Map<String, String>>,
 }
 
 #[contracttype]
@@ -128,6 +129,7 @@ impl StellarStreamContract {
         start_time: u64,
         end_time: u64,
         cliff_seconds: u64,
+        metadata: Option<Map<String, String>>,
     ) -> u64 {
         sender.require_auth();
 
@@ -174,7 +176,7 @@ impl StellarStreamContract {
             canceled: false,
             paused: false,
             pause_started_at: None,
-            metadata: None,
+            metadata: metadata.clone(),
         };
 
         env.storage()
@@ -196,6 +198,7 @@ impl StellarStreamContract {
                 start_time,
                 end_time,
                 cliff_seconds,
+                metadata,
             },
         );
 
@@ -258,6 +261,7 @@ impl StellarStreamContract {
                 claimed_amount: 0,
                 start_time,
                 end_time,
+                cliff_seconds: 0,
                 canceled: false,
                 paused: false,
                 pause_started_at: None,
@@ -282,6 +286,7 @@ impl StellarStreamContract {
                     total_amount: allocation,
                     start_time,
                     end_time,
+                    cliff_seconds: 0,
                     metadata: None,
                 },
             );

--- a/contracts/src/snapshots/stellar_stream__test__stream_created_event.snap
+++ b/contracts/src/snapshots/stellar_stream__test__stream_created_event.snap
@@ -12,5 +12,6 @@ StreamCreated {
     total_amount: 1000,
     start_time: 100,
     end_time: 200,
+    cliff_seconds: 0,
     metadata: None,
 }

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -52,9 +52,9 @@ fn test_get_next_stream_id() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &5000);
-    client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0);
+    client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
     assert_eq!(client.get_next_stream_id(), 1);
-    client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0);
+    client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
     assert_eq!(client.get_next_stream_id(), 2);
 }
 
@@ -70,7 +70,7 @@ fn test_claim_transfers_tokens_to_recipient() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     env.ledger().with_mut(|l| l.timestamp = 500);
     let claimed = client.claim(&stream_id, &recipient, &500);
     assert_eq!(claimed, 500);
@@ -90,7 +90,7 @@ fn test_claim_partial_then_full() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     env.ledger().with_mut(|l| l.timestamp = 500);
     client.claim(&stream_id, &recipient, &300);
     env.ledger().with_mut(|l| l.timestamp = 1000);
@@ -112,7 +112,7 @@ fn test_claim_cannot_exceed_vested_amount() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     env.ledger().with_mut(|l| l.timestamp = 250);
     client.claim(&stream_id, &recipient, &500);
 }
@@ -130,7 +130,7 @@ fn test_claim_cannot_double_claim() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     env.ledger().with_mut(|l| l.timestamp = 500);
     client.claim(&stream_id, &recipient, &500);
     client.claim(&stream_id, &recipient, &500);
@@ -150,7 +150,7 @@ fn test_claim_fails_with_wrong_recipient() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     env.ledger().with_mut(|l| l.timestamp = 500);
     client.claim(&stream_id, &wrong_recipient, &500);
 }
@@ -168,7 +168,7 @@ fn test_create_stream_fails_with_insufficient_sender_balance() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &100);
-    client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
 }
 
 #[test]
@@ -183,7 +183,7 @@ fn test_claimable_before_stream_start_returns_zero() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
     assert_eq!(client.claimable(&stream_id, &999), 0);
     assert_eq!(client.claimable(&stream_id, &1000), 0);
 }
@@ -200,7 +200,7 @@ fn test_claimable_during_stream_is_linear() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     assert_eq!(client.claimable(&stream_id, &250), 250);
     assert_eq!(client.claimable(&stream_id, &500), 500);
     assert_eq!(client.claimable(&stream_id, &750), 750);
@@ -218,7 +218,7 @@ fn test_claimable_accounts_for_already_claimed() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     env.ledger().with_mut(|l| l.timestamp = 500);
     client.claim(&stream_id, &recipient, &300);
     assert_eq!(client.claimable(&stream_id, &500), 200);
@@ -236,7 +236,7 @@ fn test_claimable_after_stream_end_caps_at_total() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     assert_eq!(client.claimable(&stream_id, &1000), 1000);
     assert_eq!(client.claimable(&stream_id, &9999), 1000);
 }
@@ -253,7 +253,7 @@ fn test_cancel_refunds_unclaimed_to_sender() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     env.ledger().with_mut(|l| l.timestamp = 500);
     client.cancel(&stream_id, &sender);
     let token_client = token::Client::new(&env, &token);
@@ -272,7 +272,7 @@ fn test_cancel_marks_stream_as_canceled() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     client.cancel(&stream_id, &sender);
     let stream = client.get_stream(&stream_id);
     assert!(stream.canceled);
@@ -290,7 +290,7 @@ fn test_cancel_idempotent_double_cancel_does_not_panic() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     client.cancel(&stream_id, &sender);
     client.cancel(&stream_id, &sender);
 }
@@ -307,7 +307,7 @@ fn test_cancel_recipient_cannot_claim_beyond_vested_at_cancel_time() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     env.ledger().with_mut(|l| l.timestamp = 500);
     client.cancel(&stream_id, &sender);
     client.claim(&stream_id, &recipient, &500);
@@ -329,7 +329,7 @@ fn test_cancel_fails_with_wrong_sender() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     client.cancel(&stream_id, &wrong_sender);
 }
 
@@ -346,7 +346,7 @@ fn test_claim_zero_amount_panics() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     env.ledger().with_mut(|l| l.timestamp = 500);
     client.claim(&stream_id, &recipient, &0);
 }
@@ -364,7 +364,7 @@ fn test_claim_before_stream_start_panics() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
     client.claim(&stream_id, &recipient, &1);
 }
 
@@ -390,7 +390,7 @@ fn test_create_stream_zero_amount_panics() {
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
     let token = create_token(&env, &admin);
-    client.create_stream(&sender, &recipient, &token, &0, &0, &1000, &0);
+    client.create_stream(&sender, &recipient, &token, &0, &0, &1000, &0, &None);
 }
 
 #[test]
@@ -406,7 +406,7 @@ fn test_create_stream_invalid_time_range_panics() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    client.create_stream(&sender, &recipient, &token, &1000, &1000, &1000, &0);
+    client.create_stream(&sender, &recipient, &token, &1000, &1000, &1000, &0, &None);
 }
 
 #[test]
@@ -425,7 +425,7 @@ fn test_event_emissions() {
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
 
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     let last_event = env.events().all().last().unwrap();
 
     assert_eq!(last_event.0, contract_id);
@@ -448,6 +448,7 @@ fn test_event_emissions() {
             start_time: 0,
             end_time: 1000,
             cliff_seconds: 0,
+            metadata: None,
         }
     );
 
@@ -506,6 +507,7 @@ fn test_stream_created_snapshot() {
         total_amount: 1000,
         start_time: 100,
         end_time: 200,
+        cliff_seconds: 0,
         metadata: None,
     };
 
@@ -534,7 +536,7 @@ fn test_native_xlm_streaming() {
     
     client.initialize(&admin, &native_token_address);
 
-    let stream_id = client.create_stream(&sender, &recipient, &sentinel, &500, &0, &1000, &None);
+    let stream_id = client.create_stream(&sender, &recipient, &sentinel, &500, &0, &1000, &0, &None);
     let stream = client.get_stream(&stream_id);
     assert_eq!(stream.token, sentinel);
     
@@ -627,7 +629,7 @@ fn test_pause_resume_freezes_vesting_and_extends_end_time() {
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
 
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &None);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
     env.ledger().with_mut(|l| l.timestamp = 300);
     client.pause_stream(&stream_id, &sender);
     assert_eq!(client.claimable(&stream_id, &450), 300);
@@ -654,6 +656,7 @@ fn test_vested_amount_fuzz_invariants() {
         claimed_amount: 0,
         start_time: 100,
         end_time: 10_100,
+        cliff_seconds: 0,
         canceled: false,
         paused: false,
         pause_started_at: None,
@@ -688,7 +691,7 @@ fn test_claimable_at_start_time() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &None);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
     assert_eq!(client.claimable(&stream_id, &1000), 0);
 }
 
@@ -704,7 +707,7 @@ fn test_claimable_at_end_time() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &None);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
     assert_eq!(client.claimable(&stream_id, &2000), 1000);
 }
 
@@ -720,7 +723,7 @@ fn test_claimable_after_end_time() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &None);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
     assert_eq!(client.claimable(&stream_id, &2100), 1000);
 }
 
@@ -742,7 +745,7 @@ fn test_cancel_before_start_refunds_full_amount_to_sender() {
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
 
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &500, &1500, &None);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &500, &1500, &0, &None);
 
     env.ledger().with_mut(|l| l.timestamp = 0);
     client.cancel(&stream_id, &sender);
@@ -766,7 +769,7 @@ fn test_cancel_before_start_recipient_claimable_is_zero() {
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
 
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &500, &1500, &None);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &500, &1500, &0, &None);
 
     env.ledger().with_mut(|l| l.timestamp = 0);
     client.cancel(&stream_id, &sender);
@@ -790,7 +793,7 @@ fn test_cancel_before_start_claim_attempt_panics() {
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
 
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &500, &1500, &None);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &500, &1500, &0, &None);
 
     env.ledger().with_mut(|l| l.timestamp = 0);
     client.cancel(&stream_id, &sender);
@@ -800,9 +803,11 @@ fn test_cancel_before_start_claim_attempt_panics() {
 }
 
 // -----------------------------------------------------------------
-// CANCEL MID-STREAM
+// CANCEL MID-STREAM / CLIFF VESTING
 // -----------------------------------------------------------------
 
+#[test]
+fn test_cliff_vesting_blocks_claim_before_cliff() {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register_contract(None, StellarStreamContract);
@@ -815,7 +820,7 @@ fn test_cancel_before_start_claim_attempt_panics() {
     token_admin.mint(&sender, &1000);
 
     // Create stream with cliff of 250 seconds
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &250);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &250, &None);
 
     // Before cliff, claimable is 0
     assert_eq!(client.claimable(&stream_id, &249), 0);
@@ -840,7 +845,7 @@ fn test_transfer_stream_updates_recipient() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &None);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
 
     client.transfer_stream(&stream_id, &new_recipient);
 
@@ -871,7 +876,7 @@ fn test_transfer_stream_accrues_to_new_recipient() {
     let token = create_token(&env, &admin);
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &None);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
 
     env.ledger().with_mut(|l| l.timestamp = 250);
     // 250 vested, recipient claims 100
@@ -902,7 +907,7 @@ fn test_claim_rapid_succession_prevents_double_pay() {
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
 
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &None);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &None);
 
     // Advance ledger to 100% vested
     env.ledger().with_mut(|l| l.timestamp = 1000);
@@ -914,6 +919,10 @@ fn test_claim_rapid_succession_prevents_double_pay() {
     // Total paid never exceeds total_amount (verified by checking balance)
     let token_client = token::Client::new(&env, &token);
     assert_eq!(token_client.balance(&recipient), 1000);
+
+    // Second claim for same amount panics — enforced by should_panic above
+    client.claim(&stream_id, &recipient, &1000);
+}
 
 /// Multiple key-value pairs survive the round-trip through storage.
 #[test]
@@ -935,9 +944,7 @@ fn test_metadata_multiple_labels_round_trip() {
     meta.set(String::from_str(&env, "project"), String::from_str(&env, "xlm-vesting"));
     meta.set(String::from_str(&env, "cost_center"), String::from_str(&env, "cc-42"));
 
-    let stream_id = client.create_stream(
-        &sender, &recipient, &token, &1000, &0, &1000,
-        &Some(meta.clone()),
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &0, &1000, &0, &Some(meta.clone()),
     );
 
     let stream = client.get_stream(&stream_id);
@@ -1005,7 +1012,8 @@ fn test_clawback_transfers_to_admin() {
 
     client.initialize(&compliance_admin, &Address::generate(&env));
     let stream_id = client.create_stream(
-        &sender, &recipient, &token, &1000, &0, &1000, &None,
+        &sender, &recipient, &token, &1000, &0, &1000, &0,
+        &None,
     );
 
     // At t=500, vested = 500, claimed = 0 → max clawback = 500
@@ -1035,7 +1043,8 @@ fn test_clawback_caps_at_unclaimed_vested() {
 
     client.initialize(&compliance_admin, &Address::generate(&env));
     let stream_id = client.create_stream(
-        &sender, &recipient, &token, &1000, &0, &1000, &None,
+        &sender, &recipient, &token, &1000, &0, &1000, &0,
+        &None,
     );
 
     // At t=400, vested = 400 → requesting 1000 should be capped to 400
@@ -1062,7 +1071,8 @@ fn test_clawback_reduces_recipient_claimable() {
 
     client.initialize(&compliance_admin, &Address::generate(&env));
     let stream_id = client.create_stream(
-        &sender, &recipient, &token, &1000, &0, &1000, &None,
+        &sender, &recipient, &token, &1000, &0, &1000, &0,
+        &None,
     );
 
     // At t=500, vested = 500; admin claws back 200
@@ -1098,7 +1108,8 @@ fn test_clawback_non_admin_panics() {
 
     client.initialize(&compliance_admin, &Address::generate(&env));
     let stream_id = client.create_stream(
-        &sender, &recipient, &token, &1000, &0, &1000, &None,
+        &sender, &recipient, &token, &1000, &0, &1000, &0,
+        &None,
     );
 
     env.ledger().with_mut(|l| l.timestamp = 500);
@@ -1124,7 +1135,7 @@ fn test_clawback_before_initialize_panics() {
     token_mint.mint(&sender, &1000);
 
     let stream_id = client.create_stream(
-        &sender, &recipient, &token, &1000, &0, &1000, &None,
+        &sender, &recipient, &token, &1000, 0, 1000, 0, &None,
     );
     env.ledger().with_mut(|l| l.timestamp = 500);
     client.clawback(&stream_id, &100, &someone);
@@ -1148,7 +1159,8 @@ fn test_clawback_emits_event() {
 
     client.initialize(&compliance_admin, &Address::generate(&env));
     let stream_id = client.create_stream(
-        &sender, &recipient, &token, &1000, &0, &1000, &None,
+        &sender, &recipient, &token, &1000, &0, &1000, &0,
+        &None,
     );
 
     env.ledger().with_mut(|l| l.timestamp = 500);
@@ -1184,7 +1196,8 @@ fn test_clawback_token_conservation() {
 
     client.initialize(&compliance_admin, &Address::generate(&env));
     let stream_id = client.create_stream(
-        &sender, &recipient, &token, &1000, &0, &1000, &None,
+        &sender, &recipient, &token, &1000, &0, &1000, &0,
+        &None,
     );
 
     // Recipient claims 200 at t=400
@@ -1260,7 +1273,7 @@ fn test_pause_resume_normal_flow() {
     token_admin.mint(&sender, &1000);
 
     // Create stream: start at 1000, end at 2000
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
 
     // Advance to t=1100 and pause
     env.ledger().with_mut(|l| l.timestamp = 1100);
@@ -1298,7 +1311,7 @@ fn test_claimable_while_paused_clamped() {
     token_admin.mint(&sender, &1000);
 
     // Create stream: start at 1000, end at 2000 (total 1000 units)
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
 
     // Advance to t=1500 (50% vested) and pause
     env.ledger().with_mut(|l| l.timestamp = 1500);
@@ -1323,7 +1336,7 @@ fn test_vested_constant_while_paused() {
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
 
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
 
     env.ledger().with_mut(|l| l.timestamp = 1500);
     client.pause_stream(&stream_id, &sender);
@@ -1349,7 +1362,7 @@ fn test_vesting_resumes_after_resume() {
     token_admin.mint(&sender, &1000);
 
     // 1000-2000 duration
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
 
     // Pause at 1500 (50% vested)
     env.ledger().with_mut(|l| l.timestamp = 1500);
@@ -1383,7 +1396,7 @@ fn test_pause_at_start_time_vested_is_zero() {
     token_admin.mint(&sender, &1000);
 
     // Start at 1000
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
 
     // Pause exactly at start_time
     env.ledger().with_mut(|l| l.timestamp = 1000);
@@ -1409,7 +1422,7 @@ fn test_pause_resume_snapshot_lifecycle() {
     token_admin.mint(&sender, &1000);
 
     // 1. Create stream: start at 1000, end at 2000
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
 
     // 2. Pause midway at t=1500
     env.ledger().with_mut(|l| l.timestamp = 1500);
@@ -1458,7 +1471,7 @@ fn test_pause_already_paused_stream_panics() {
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
 
-    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0);
+    let stream_id = client.create_stream(&sender, &recipient, &token, &1000, &1000, &2000, &0, &None);
     
     env.ledger().with_mut(|l| l.timestamp = 1500);
     client.pause_stream(&stream_id, &sender);
@@ -1482,11 +1495,9 @@ fn test_create_split_stream_success() {
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
 
-    let recipients = vec![
-        &env,
-        (r1.clone(), 400_i128),
-        (r2.clone(), 600_i128),
-    ];
+    let recipients = Vec::new(&env);
+    recipients.push_back((r1.clone(), 400_i128));
+    recipients.push_back((r2.clone(), 600_i128));;
 
     // 400 + 600 = 1000 (matches total_amount)
     let parent_id = client.create_split_stream(&sender, &token, &1000, &1000, &2000, &recipients);
@@ -1523,11 +1534,9 @@ fn test_create_split_stream_undersum_panics() {
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
 
-    let recipients = vec![
-        &env,
-        (Address::generate(&env), 400_i128),
-        (Address::generate(&env), 500_i128),
-    ];
+    let recipients = Vec::new(&env);
+    recipients.push_back((Address::generate(&env), 400_i128));
+    recipients.push_back((Address::generate(&env), 500_i128));;
 
     // 400 + 500 = 900 != 1000
     client.create_split_stream(&sender, &token, &1000, &1000, &2000, &recipients);
@@ -1547,11 +1556,9 @@ fn test_create_split_stream_oversum_panics() {
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1100);
 
-    let recipients = vec![
-        &env,
-        (Address::generate(&env), 600_i128),
-        (Address::generate(&env), 500_i128),
-    ];
+    let recipients = Vec::new(&env);
+    recipients.push_back((Address::generate(&env), 600_i128));
+    recipients.push_back((Address::generate(&env), 500_i128));;
 
     // 600 + 500 = 1100 != 1000
     client.create_split_stream(&sender, &token, &1000, &1000, &2000, &recipients);
@@ -1571,7 +1578,388 @@ fn test_create_split_stream_empty_recipients_panics() {
     let token_admin = token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&sender, &1000);
 
-    let recipients = vec![&env];
+    let recipients = Vec::<(Address, i128)>::new(&env);
 
     client.create_split_stream(&sender, &token, &1000, &1000, &2000, &recipients);
+}
+
+// =============================================================================
+// #214 — StreamCreated event snapshot tests with metadata
+// =============================================================================
+
+/// Snapshot of StreamCreated event when metadata = None (named baseline).
+#[test]
+fn test_stream_created_no_metadata_snapshot() {
+    let env = Env::default();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let event = StreamCreated {
+        stream_id: 1,
+        sender: sender.clone(),
+        recipient: recipient.clone(),
+        token: token.clone(),
+        token_symbol: soroban_sdk::String::from_str(&env, "TEST"),
+        total_amount: 1000,
+        start_time: 100,
+        end_time: 200,
+        cliff_seconds: 0,
+        metadata: None,
+    };
+
+    assert_snapshot!("stream_created_no_metadata", event);
+}
+
+/// Snapshot of StreamCreated event when metadata is populated.
+/// Verifies metadata key/value pairs survive round-trip through Soroban event emission.
+#[test]
+fn test_stream_created_with_metadata_snapshot() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    let meta = make_metadata(&env);
+    let stream_id = client.create_stream(
+        &sender, &recipient, &token, &1000, &0, &1000, &0,
+        &Some(meta.clone()),
+    );
+
+    // Capture the emitted StreamCreated event
+    let last_event = env.events().all().last().unwrap();
+    assert_eq!(
+        last_event.1,
+        (symbol_short!("Stream"), symbol_short!("Created")).into_val(&env)
+    );
+    let event_data: StreamCreated = last_event.2.into_val(&env);
+
+    // Verify metadata key/value pairs survive round-trip
+    let stored_meta = event_data.metadata.clone().unwrap();
+    assert_eq!(
+        stored_meta.get(soroban_sdk::String::from_str(&env, "department")),
+        Some(soroban_sdk::String::from_str(&env, "engineering"))
+    );
+
+    // Also verify the stream itself stored the metadata
+    let stream = client.get_stream(&stream_id);
+    assert_eq!(stream.metadata, Some(meta));
+
+    assert_snapshot!("stream_created_with_metadata", event_data);
+}
+
+/// Large metadata map (10 entries) does not cause storage budget issues.
+#[test]
+fn test_stream_created_large_metadata_no_budget_panic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &1000);
+
+    let mut large_meta = Map::new(&env);
+    for i in 0u32..10 {
+        let key = soroban_sdk::String::from_str(&env, "key");
+        let val = soroban_sdk::String::from_str(&env, "val");
+        large_meta.set(key, val);
+        let _ = i; // suppress unused warning
+    }
+    large_meta.set(
+        soroban_sdk::String::from_str(&env, "k0"), soroban_sdk::String::from_str(&env, "v0"),
+    );
+    large_meta.set(
+        soroban_sdk::String::from_str(&env, "k1"), soroban_sdk::String::from_str(&env, "v1"),
+    );
+    large_meta.set(
+        soroban_sdk::String::from_str(&env, "k2"), soroban_sdk::String::from_str(&env, "v2"),
+    );
+    large_meta.set(
+        soroban_sdk::String::from_str(&env, "k3"), soroban_sdk::String::from_str(&env, "v3"),
+    );
+    large_meta.set(
+        soroban_sdk::String::from_str(&env, "k4"), soroban_sdk::String::from_str(&env, "v4"),
+    );
+    large_meta.set(
+        soroban_sdk::String::from_str(&env, "k5"), soroban_sdk::String::from_str(&env, "v5"),
+    );
+    large_meta.set(
+        soroban_sdk::String::from_str(&env, "k6"), soroban_sdk::String::from_str(&env, "v6"),
+    );
+    large_meta.set(
+        soroban_sdk::String::from_str(&env, "k7"), soroban_sdk::String::from_str(&env, "v7"),
+    );
+    large_meta.set(
+        soroban_sdk::String::from_str(&env, "k8"), soroban_sdk::String::from_str(&env, "v8"),
+    );
+    large_meta.set(
+        soroban_sdk::String::from_str(&env, "k9"), soroban_sdk::String::from_str(&env, "v9"),
+    );
+
+    // Should not panic — no budget issues with 10 entries
+    let stream_id = client.create_stream(
+        &sender, &recipient, &token, &1000, &0, &1000, &0,
+        &Some(large_meta.clone()),
+    );
+
+    let stream = client.get_stream(&stream_id);
+    assert!(stream.metadata.is_some());
+    assert_eq!(
+        stream.metadata.unwrap().get(soroban_sdk::String::from_str(&env, "k9")),
+        Some(soroban_sdk::String::from_str(&env, "v9"))
+    );
+}
+
+// =============================================================================
+// #213 — initialize guard: prevent double initialization
+// =============================================================================
+
+/// First initialize stores admin correctly.
+#[test]
+fn test_initialize_guard_stores_admin_on_first_call() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let native_token = Address::generate(&env);
+
+    // First call must not panic
+    client.initialize(&admin, &native_token);
+
+    // Admin is stored — verify by confirming clawback uses it (non-admin panics)
+    // We just verify no panic on first init; admin storage is confirmed by clawback tests.
+}
+
+/// Double initialization panics with "already initialized".
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_initialize_guard_double_init_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let native_token = Address::generate(&env);
+
+    client.initialize(&admin, &native_token);
+    // Second call must panic
+    client.initialize(&admin, &native_token);
+}
+
+/// Double initialization with a different admin also panics — no privilege escalation.
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_initialize_guard_different_admin_cannot_replace() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let native_token = Address::generate(&env);
+
+    client.initialize(&admin, &native_token);
+    // Attacker tries to replace admin — must panic
+    client.initialize(&attacker, &native_token);
+}
+
+/// Clawback is rejected before initialize is called (no admin set).
+#[test]
+#[should_panic(expected = "contract not initialized")]
+fn test_initialize_guard_clawback_rejected_before_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token(&env, &token_admin);
+    let token_mint = token::StellarAssetClient::new(&env, &token);
+    token_mint.mint(&sender, &1000);
+
+    let stream_id = client.create_stream(
+        &sender, &recipient, &token, &1000, &0, &1000, &0, &None,
+    );
+    env.ledger().with_mut(|l| l.timestamp = 500);
+
+    // No initialize called — clawback must panic with "contract not initialized"
+    client.clawback(&stream_id, &100, &sender);
+}
+
+// =============================================================================
+// #218 — Stream ID auto-increment across split stream creation
+// =============================================================================
+
+/// After a regular stream, next ID is 1.
+/// After a split stream with 3 recipients, next ID is 5 (1 parent + 3 children).
+/// After another regular stream, ID is 6 (no collision).
+#[test]
+fn test_stream_id_auto_increment_across_split_stream() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let r3 = Address::generate(&env);
+    let r4 = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &10000);
+
+    // Regular stream → ID 1, next = 1
+    let regular_id = client.create_stream(
+        &sender, &r1, &token, &100, &0, &1000, &0, &None,
+    );
+    assert_eq!(regular_id, 1);
+    assert_eq!(client.get_next_stream_id(), 1);
+
+    // Split stream with 3 recipients → parent = 2, children = 3, 4, 5; next = 5
+    let mut recipients = Vec::new(&env);
+    recipients.push_back((r2.clone(), 300_i128));
+    recipients.push_back((r3.clone(), 300_i128));
+    recipients.push_back((r4.clone(), 400_i128));
+
+    let parent_id = client.create_split_stream(
+        &sender, &token, &1000, &0, &1000, &recipients,
+    );
+    assert_eq!(parent_id, 2);
+    assert_eq!(client.get_next_stream_id(), 5);
+
+    // Child IDs are contiguous: 3, 4, 5
+    let children = client.get_split_children(&parent_id);
+    assert_eq!(children.len(), 3);
+    assert_eq!(children.get(0).unwrap(), 3);
+    assert_eq!(children.get(1).unwrap(), 4);
+    assert_eq!(children.get(2).unwrap(), 5);
+
+    // Another regular stream → ID 6, no collision
+    let next_regular_id = client.create_stream(
+        &sender, &r1, &token, &100, &0, &1000, &0, &None,
+    );
+    assert_eq!(next_regular_id, 6);
+    assert_eq!(client.get_next_stream_id(), 6);
+}
+
+/// Child stream IDs are contiguous and match SplitChildren mapping.
+#[test]
+fn test_split_stream_child_ids_are_contiguous_and_match_mapping() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &5000);
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+
+    let mut recipients = Vec::new(&env);
+    recipients.push_back((r1.clone(), 500_i128));
+    recipients.push_back((r2.clone(), 500_i128));
+
+    let parent_id = client.create_split_stream(
+        &sender, &token, &1000, &0, &1000, &recipients,
+    );
+
+    let children = client.get_split_children(&parent_id);
+    assert_eq!(children.len(), 2);
+
+    // Children must be contiguous starting at parent_id + 1
+    let c0 = children.get(0).unwrap();
+    let c1 = children.get(1).unwrap();
+    assert_eq!(c0, parent_id + 1);
+    assert_eq!(c1, parent_id + 2);
+
+    // Verify each child stream is retrievable and has correct recipient
+    let stream_c0 = client.get_stream(&c0);
+    let stream_c1 = client.get_stream(&c1);
+    assert_eq!(stream_c0.recipient, r1);
+    assert_eq!(stream_c1.recipient, r2);
+}
+
+/// No ID collisions across multiple mixed stream creations.
+#[test]
+fn test_no_id_collisions_across_mixed_stream_creations() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarStreamContract);
+    let client = StellarStreamContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&sender, &50000);
+
+    let mut seen_ids: std::vec::Vec<u64> = std::vec::Vec::new();
+
+    // Regular stream → ID 1
+    let id1 = client.create_stream(
+        &sender, &Address::generate(&env), &token, &100, &0, &1000, &0, &None,
+    );
+    seen_ids.push(id1);
+
+    // Split with 2 recipients → parent = 2, children = 3, 4
+    let mut r2 = Vec::new(&env);
+    r2.push_back((Address::generate(&env), 50_i128));
+    r2.push_back((Address::generate(&env), 50_i128));
+    let parent2 = client.create_split_stream(&sender, &token, &100, &0, &1000, &r2);
+    seen_ids.push(parent2);
+    for child in client.get_split_children(&parent2).iter() {
+        seen_ids.push(child);
+    }
+
+    // Regular stream → ID 5
+    let id5 = client.create_stream(
+        &sender, &Address::generate(&env), &token, &100, &0, &1000, &0, &None,
+    );
+    seen_ids.push(id5);
+
+    // Split with 1 recipient → parent = 6, child = 7
+    let mut r3 = Vec::new(&env);
+    r3.push_back((Address::generate(&env), 100_i128));
+    let parent6 = client.create_split_stream(&sender, &token, &100, &0, &1000, &r3);
+    seen_ids.push(parent6);
+    for child in client.get_split_children(&parent6).iter() {
+        seen_ids.push(child);
+    }
+
+    // All IDs must be unique
+    let unique_count = {
+        let mut sorted = seen_ids.clone();
+        sorted.sort();
+        sorted.dedup();
+        sorted.len()
+    };
+    assert_eq!(unique_count, seen_ids.len(), "ID collision detected: {:?}", seen_ids);
+
+    // next_stream_id must equal the highest ID seen
+    let max_id = seen_ids.iter().copied().max().unwrap();
+    assert_eq!(client.get_next_stream_id(), max_id);
 }


### PR DESCRIPTION
What changed
contracts/src/lib.rs

Added metadata: Option<Map<String, String>> field to StreamCreated event struct
Added metadata parameter to create_stream function so callers can attach metadata at creation time
Metadata is now stored on the stream and emitted in the StreamCreated event
Added cliff_seconds to the split stream child StreamCreated event emission (was missing)
contracts/src/test.rs

Fixed pre-existing broken test bodies (missing #[test] fn headers, unclosed braces)
Updated all create_stream call sites to the new 8-argument signature
Added snapshot test test_stream_created_with_metadata_snapshot — verifies metadata key/value pairs survive round-trip through Soroban event emission
Added snapshot test test_stream_created_no_metadata_snapshot — named baseline with metadata: None
Added test_stream_created_large_metadata_no_budget_panic — 10-entry map causes no storage budget panic
Added test_initialize_guard_stores_admin_on_first_call — first init succeeds
Added test_initialize_guard_double_init_panics — second call panics with "already initialized"
Added test_initialize_guard_different_admin_cannot_replace — attacker cannot replace admin
Added test_initialize_guard_clawback_rejected_before_init — clawback panics before init
Added test_stream_id_auto_increment_across_split_stream — verifies ID sequence after regular + split + regular
Added test_split_stream_child_ids_are_contiguous_and_match_mapping — children start at parent_id + 1
Added test_no_id_collisions_across_mixed_stream_creations — no collisions across multiple creation types
backend/src/services/streamStore.reconcile.test.ts (new file)

inserts on-chain streams missing from local SQLite with correct field mapping
does not duplicate rows for streams already present in local DB
only backfills the missing stream when some are present and some are not
does not crash when RPC times out — logs error and returns 0
is idempotent — running twice does not duplicate rows or events
Closes #214 Closes #213 Closes #218 Closes #220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streams now support optional metadata during creation for additional customization and context.
  * Split-stream child streams now correctly enforce zero cliff duration by default.

* **Tests**
  * Expanded test coverage for stream creation, metadata handling, split-stream behavior, and edge cases including RPC timeouts and idempotency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->