### PR TITLE
Add: Added tests for authMiddleware – protected route rejection witho…

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,6 @@
         "express-rate-limit": "^7.5.0",
         "jsonwebtoken": "^9.0.2",
         "p-limit": "^4.0.0",
-
         "swagger-ui-express": "^5.0.1",
         "ws": "^8.20.0",
         "zod": "^4.3.6"
@@ -508,15 +507,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
-      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -1492,12 +1482,6 @@
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
-    },
-    "node_modules/bintrees": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
-      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
-      "license": "MIT"
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -3496,19 +3480,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/prom-client": {
-      "version": "15.1.3",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
-      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.4.0",
-        "tdigest": "^0.1.1"
-      },
-      "engines": {
-        "node": "^16 || ^18 || >=20"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4256,15 +4227,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tdigest": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
-      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
-      "license": "MIT",
-      "dependencies": {
-        "bintrees": "1.0.2"
       }
     },
     "node_modules/tinybench": {

--- a/backend/src/services/auth.test.ts
+++ b/backend/src/services/auth.test.ts
@@ -13,7 +13,7 @@ const serverKeypair = Keypair.random();
 vi.stubEnv("SERVER_SIGNING_KEY", serverKeypair.secret());
 
 // Import after env stubs are in place
-const { verifyChallengeAndIssueToken } = await import("./auth");
+const { verifyChallengeAndIssueToken, authMiddleware } = await import("./auth");
 
 function buildSignedChallenge(clientKeypair: Keypair): string {
   const challenge = WebAuth.buildChallengeTx(
@@ -180,6 +180,100 @@ describe("verifyChallengeAndIssueToken", () => {
       await expect(verifyChallengeAndIssueToken("not-a-valid-tx")).rejects.toThrow(
         "Challenge verification failed",
       );
+    });
+  });
+});
+
+describe("authMiddleware", () => {
+  let req: any;
+  let res: any;
+  let next: any;
+
+  beforeEach(() => {
+    req = {
+      headers: {},
+      requestId: "test-request-id",
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+    next = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls next() and attaches user to context with valid JWT", () => {
+    const payload = { accountId: "GTEST123" };
+    const token = jwt.sign(payload, TEST_JWT_SECRET, { expiresIn: "1h" });
+    req.headers.authorization = `Bearer ${token}`;
+
+    authMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user.accountId).toBe(payload.accountId);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 with token_expired error code for expired JWT", () => {
+    const payload = { accountId: "GTEST123" };
+    const token = jwt.sign(payload, TEST_JWT_SECRET, { expiresIn: "-1h" }); // Expired
+    req.headers.authorization = `Bearer ${token}`;
+
+    authMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Authorization token has expired.",
+      statusCode: 401,
+      requestId: "test-request-id",
+      code: "token_expired",
+    });
+  });
+
+  it("returns 401 with unauthorized error code for no Authorization header", () => {
+    authMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Missing or invalid authorization header.",
+      statusCode: 401,
+      requestId: "test-request-id",
+      code: "unauthorized",
+    });
+  });
+
+  it("returns 401 with invalid_token error code for malformed token", () => {
+    req.headers.authorization = "Bearer invalid.jwt.token";
+
+    authMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Invalid authorization token.",
+      statusCode: 401,
+      requestId: "test-request-id",
+      code: "invalid_token",
+    });
+  });
+
+  it("returns 401 with unauthorized error code for invalid Authorization header format", () => {
+    req.headers.authorization = "InvalidFormat";
+
+    authMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Missing or invalid authorization header.",
+      statusCode: 401,
+      requestId: "test-request-id",
+      code: "unauthorized",
     });
   });
 });

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -215,7 +215,7 @@ export function authMiddleware(
 
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
     sendApiError(req, res, 401, "Missing or invalid authorization header.", {
-      code: "UNAUTHORIZED",
+      code: "unauthorized",
     });
     return;
   }
@@ -226,9 +226,15 @@ export function authMiddleware(
     const decoded = jwt.verify(token, getJwtSecret()) as AuthUser;
     (req as any).user = decoded; // Attach user to request
     next();
-  } catch (error) {
-    sendApiError(req, res, 401, "Invalid or expired authorization token.", {
-      code: "UNAUTHORIZED",
-    });
+  } catch (error: any) {
+    if (error.name === "TokenExpiredError") {
+      sendApiError(req, res, 401, "Authorization token has expired.", {
+        code: "token_expired",
+      });
+    } else {
+      sendApiError(req, res, 401, "Invalid authorization token.", {
+        code: "invalid_token",
+      });
+    }
   }
 }


### PR DESCRIPTION
Close #267 

Read [](file:///workspaces/stellar-stream/PR_DESCRIPTION.md)

## Add Tests for authMiddleware – Protected Route Rejection Without Valid JWT

## Description
This PR adds comprehensive tests for the `authMiddleware` function to ensure protected write endpoints properly reject unauthenticated requests. The middleware blocks requests without valid JWTs, and these tests verify all error scenarios return appropriate 401 responses with correct error codes, preventing silent failures that could be missed in CI.

## Changes Made
### Backend
- **authMiddleware Enhancement (auth.ts):** Updated error handling to distinguish between different JWT validation failures:
  - Expired tokens return `code: "token_expired"`
  - Invalid/malformed tokens return `code: "invalid_token"`
  - Missing or invalid headers return `code: "unauthorized"`
- **Test Suite Expansion (auth.test.ts):** Added 5 new test cases covering all authMiddleware scenarios:
  - Valid JWT allows request to proceed and attaches user to context
  - Expired JWT returns 401 with `token_expired` error code
  - No Authorization header returns 401 with `unauthorized` error code
  - Malformed token returns 401 with `invalid_token` error code (not 500)
  - Invalid header format returns 401 with `unauthorized` error code

## Acceptance Criteria
- [x] All three rejection cases produce 401, not 500
- [x] Valid token allows the request to proceed
- [x] Error codes match the API error schema (`token_expired`, `unauthorized`, `invalid_token`)

## Testing Instructions
1. Navigate to the backend directory: `cd backend`
2. Install dependencies: `npm install`
3. Run the auth tests: `npx vitest run src/services/auth.test.ts`
4. Verify all 10 tests pass (5 existing + 5 new authMiddleware tests)
5. Confirm each authMiddleware test scenario:
   - Valid JWT test calls `next()` and attaches user to `req.user`
   - Expired JWT test returns 401 with `token_expired` code
   - No header test returns 401 with `unauthorized` code
   - Malformed token test returns 401 with `invalid_token` code (not 500)
   - Invalid format test returns 401 with `unauthorized` code
6. Run full test suite to ensure no regressions: `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error responses with more specific error codes for expired tokens, invalid tokens, and missing authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->