### PR TITLE
feat: Add Seed Script, Amount Range Filters and Add prettier seed scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,23 +8,47 @@ Check out the [FAQ.md](FAQ.md) for common contributor questions and troubleshoot
 
 1. Clone the repository
 2. Install dependencies: `npm run install:all`
-3. Run the development environment: `npm run dev`
+3. Seed demo data: `node scripts/seed-streams.js --reset`
+4. Run the development environment: `npm run dev`
+
+### Seeding Demo Data
+
+To populate your local database with deterministic demo streams:
+
+```bash
+# Seed 10 default streams
+node scripts/seed-streams.js
+
+# Seed custom number of streams
+node scripts/seed-streams.js --count 20
+
+# Reset database and seed
+node scripts/seed-streams.js --reset
+
+# Combine options
+node scripts/seed-streams.js --reset --count 15
+```
+
+The seed script creates streams across all statuses (scheduled, active, paused, completed, canceled) with deterministic data, ensuring consistent results on every run when the database is empty.
 
 ## Testing
 
 ### Backend Tests
+
 Run `npm run test` in the `backend/` directory.
 
 ### Contract Tests
+
 Run `cargo test` in the `contracts/` directory.
 
 #### Snapshot Testing
+
 We use `insta` for snapshot testing of contract events.  
 Snapshot files are located in `contracts/test_snapshots/`.
 
 **To update snapshots:**
 If you change event structures and need to update the snapshots, run:
 
-
 ```bash
 cargo insta review
+```

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -95,6 +95,14 @@ const listStreamsQuerySchema = z.object({
   sender: z.string().trim().optional(),
   asset: z.string().trim().optional(),
   q: z.string().trim().optional(),
+  minAmount: z
+    .coerce.number()
+    .nonnegative("minAmount must be a non-negative number")
+    .optional(),
+  maxAmount: z
+    .coerce.number()
+    .nonnegative("maxAmount must be a non-negative number")
+    .optional(),
   include_archived: z
     .enum(["true", "false"])
     .optional()
@@ -237,6 +245,12 @@ app.get("/api/streams", (req: Request, res: Response) => {
         stream.assetCode.toLowerCase().includes(searchTerm)
       );
     });
+  }
+  if (query.minAmount !== undefined) {
+    data = data.filter((stream) => stream.totalAmount >= query.minAmount!);
+  }
+  if (query.maxAmount !== undefined) {
+    data = data.filter((stream) => stream.totalAmount <= query.maxAmount!);
   }
 
   const total = data.length;

--- a/scripts/seed-streams.js
+++ b/scripts/seed-streams.js
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+/**
+ * Seed deterministic demo streams into the SQLite database.
+ * 
+ * Usage:
+ *   node scripts/seed-streams.js [--count N] [--reset]
+ * 
+ * Options:
+ *   --count N   Number of streams to create (default: 10)
+ *   --reset     Wipe the SQLite DB before seeding
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+// Load better-sqlite3 from backend node_modules
+const Database = require(path.join(__dirname, '..', 'backend', 'node_modules', 'better-sqlite3'));
+
+// Parse command-line arguments
+const args = process.argv.slice(2);
+let count = 10;
+let shouldReset = false;
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--count' && i + 1 < args.length) {
+    count = parseInt(args[i + 1], 10);
+    i++;
+  } else if (args[i] === '--reset') {
+    shouldReset = true;
+  }
+}
+
+// Database path
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, '..', 'data', 'streams.db');
+const dbDir = path.dirname(DB_PATH);
+
+// Ensure data directory exists
+if (!fs.existsSync(dbDir)) {
+  fs.mkdirSync(dbDir, { recursive: true });
+}
+
+// Reset database if requested
+if (shouldReset && fs.existsSync(DB_PATH)) {
+  fs.unlinkSync(DB_PATH);
+  console.log('✓ Database reset');
+}
+
+// Initialize database
+const db = new Database(DB_PATH);
+db.pragma('journal_mode = WAL');
+db.pragma('foreign_keys = ON');
+
+// Create tables if they don't exist
+db.exec(`
+  CREATE TABLE IF NOT EXISTS streams (
+    id              TEXT PRIMARY KEY,
+    sender          TEXT NOT NULL,
+    recipient       TEXT NOT NULL,
+    asset_code      TEXT NOT NULL,
+    total_amount    REAL NOT NULL,
+    duration_seconds INTEGER NOT NULL,
+    start_at        INTEGER NOT NULL,
+    created_at      INTEGER NOT NULL,
+    canceled_at     INTEGER,
+    completed_at    INTEGER,
+    refunded_amount REAL,
+    archived_at     INTEGER,
+    paused_at       INTEGER,
+    paused_duration INTEGER NOT NULL DEFAULT 0
+  );
+
+  CREATE TABLE IF NOT EXISTS stream_events (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    stream_id       TEXT NOT NULL,
+    event_type      TEXT NOT NULL,
+    ledger_sequence INTEGER,
+    timestamp       INTEGER NOT NULL,
+    actor           TEXT,
+    amount          REAL,
+    metadata        TEXT,
+    FOREIGN KEY (stream_id) REFERENCES streams(id)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_stream_events_stream_id ON stream_events(stream_id);
+  CREATE INDEX IF NOT EXISTS idx_stream_events_timestamp ON stream_events(timestamp);
+`);
+
+// Demo accounts (deterministic)
+const DEMO_ACCOUNTS = [
+  'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7UYXNMWX5XNXNXNXNXN',
+  'GBXYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE',
+  'GACDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQRST',
+  'GDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQRSTUV',
+  'GEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWX',
+];
+
+const DEMO_ASSETS = ['USDC', 'XLM', 'USDT'];
+
+// Helper to generate deterministic stream data
+function generateStream(index) {
+  const now = Math.floor(Date.now() / 1000);
+  const senderIdx = index % DEMO_ACCOUNTS.length;
+  const recipientIdx = (index + 1) % DEMO_ACCOUNTS.length;
+  const assetIdx = index % DEMO_ASSETS.length;
+
+  // Distribute streams across different statuses
+  let startAt, canceledAt, completedAt;
+  const status = ['scheduled', 'active', 'paused', 'completed', 'canceled'][index % 5];
+
+  switch (status) {
+    case 'scheduled':
+      startAt = now + 86400 * (index + 1); // Future start
+      break;
+    case 'active':
+      startAt = now - 86400; // Started yesterday
+      break;
+    case 'paused':
+      startAt = now - 86400;
+      break;
+    case 'completed':
+      startAt = now - 86400 * 10;
+      completedAt = now - 86400;
+      break;
+    case 'canceled':
+      startAt = now - 86400 * 5;
+      canceledAt = now - 86400 * 2;
+      break;
+  }
+
+  return {
+    id: String(index + 1),
+    sender: DEMO_ACCOUNTS[senderIdx],
+    recipient: DEMO_ACCOUNTS[recipientIdx],
+    assetCode: DEMO_ASSETS[assetIdx],
+    totalAmount: 1000 + index * 100,
+    durationSeconds: 86400 * (index + 1), // 1 day to N days
+    startAt,
+    createdAt: now - 86400 * (index + 1),
+    canceledAt,
+    completedAt,
+    refundedAmount: canceledAt ? (1000 + index * 100) * 0.5 : null,
+    pausedAt: status === 'paused' ? now - 43200 : null,
+    pausedDuration: status === 'paused' ? 43200 : 0,
+  };
+}
+
+// Insert streams
+const insertStream = db.prepare(`
+  INSERT OR IGNORE INTO streams (
+    id, sender, recipient, asset_code, total_amount, duration_seconds,
+    start_at, created_at, canceled_at, completed_at, refunded_amount,
+    paused_at, paused_duration
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`);
+
+const insertEvent = db.prepare(`
+  INSERT INTO stream_events (stream_id, event_type, timestamp, actor)
+  VALUES (?, ?, ?, ?)
+`);
+
+const transaction = db.transaction(() => {
+  for (let i = 0; i < count; i++) {
+    const stream = generateStream(i);
+    
+    insertStream.run(
+      stream.id,
+      stream.sender,
+      stream.recipient,
+      stream.assetCode,
+      stream.totalAmount,
+      stream.durationSeconds,
+      stream.startAt,
+      stream.createdAt,
+      stream.canceledAt,
+      stream.completedAt,
+      stream.refundedAmount,
+      stream.pausedAt,
+      stream.pausedDuration
+    );
+
+    // Record creation event
+    insertEvent.run(stream.id, 'created', stream.createdAt, stream.sender);
+
+    // Record other events based on status
+    if (stream.completedAt) {
+      insertEvent.run(stream.id, 'completed', stream.completedAt, stream.recipient);
+    }
+    if (stream.canceledAt) {
+      insertEvent.run(stream.id, 'canceled', stream.canceledAt, stream.sender);
+    }
+    if (stream.pausedAt) {
+      insertEvent.run(stream.id, 'paused', stream.pausedAt, stream.sender);
+    }
+  }
+});
+
+transaction();
+
+console.log(`✓ Seeded ${count} deterministic demo streams`);
+console.log(`  Database: ${DB_PATH}`);
+console.log(`  Statuses: scheduled, active, paused, completed, canceled`);
+
+db.close();


### PR DESCRIPTION
# Add Seed Script and Amount Range Filters

## Summary

Implements two features to improve developer experience and API filtering capabilities.

## Changes

### 1. Seed Script for Demo Data (#470)

- Added `scripts/seed-streams.js` to create deterministic demo streams
- Supports `--count` flag to control number of seeded streams (default: 10)
- Supports `--reset` flag to wipe SQLite DB before seeding
- Creates streams across all statuses: scheduled, active, paused, completed, canceled
- Generates deterministic data for consistent results on empty database
- Documented in CONTRIBUTING.md

### 2. Amount Range Filters (#454)

- Added `minAmount` query parameter to GET /api/streams
- Added `maxAmount` query parameter to GET /api/streams
- Filters combine with other filters via AND logic
- Non-numeric values return 400 validation error

# Closes #470 
# Closes #424
# Closes #467
# Closes #454


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The streams API now supports optional filtering parameters to query streams by minimum and maximum amounts.

* **Documentation**
  * Added detailed guidance on seeding a development database with deterministic demo data for local testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-stream/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->