### PR TITLE
Add pino logger with redaction for Stellar secret keys (issue #442)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,3 +32,12 @@ Once a report is received through the GitHub Security Advisory form, we commit t
 ## GitHub Security Advisories
 
 Maintainers: Please ensure that **GitHub Security Advisories** are enabled for this repository to allow researchers to submit reports privately.
+
+## Logging and Secret Redaction
+
+Server logs are configured to redact Stellar secret keys to prevent accidental leakage. The backend uses `pino` with the following protections:
+
+- Structured field redaction for paths: `*.secretKey`, `*.privateKey`, `*.seed`.
+- Regex-based redaction for any string matching `^S[0-9A-Z]{55}$` (Stellar secret seed format).
+
+If you discover logs containing secret material, please follow the private reporting process above.

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "express-rate-limit": "^7.5.0",
     "jsonwebtoken": "^9.0.2",
     "p-limit": "^4.0.0",
+    "pino": "^8.11.0",
 
     "swagger-ui-express": "^5.0.1",
     "ws": "^8.20.0",

--- a/backend/src/logger.test.ts
+++ b/backend/src/logger.test.ts
@@ -1,0 +1,19 @@
+import { redactObject } from "./logger";
+
+describe("logger redaction", () => {
+  test("redacts stellar secret keys in objects and strings", () => {
+    const secret = "S" + "A".repeat(55);
+    const obj = {
+      nested: { secretKey: secret, other: "ok" },
+      token: secret,
+      arr: [secret, { privateKey: secret }],
+    } as const;
+
+    const redacted = redactObject(obj as any);
+
+    expect(redacted.nested.secretKey).toBe("[REDACTED]");
+    expect(redacted.token).toBe("[REDACTED]");
+    expect(redacted.arr[0]).toBe("[REDACTED]");
+    expect(redacted.arr[1].privateKey).toBe("[REDACTED]");
+  });
+});

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,0 +1,41 @@
+import pino from "pino";
+
+const STELLAR_SECRET_REGEX = /^S[0-9A-Z]{55}$/;
+
+function redactValue(value: unknown): unknown {
+  if (typeof value === "string" && STELLAR_SECRET_REGEX.test(value)) {
+    return "[REDACTED]";
+  }
+  return value;
+}
+
+function redactObject(obj: any): any {
+  if (obj == null) return obj;
+  if (Array.isArray(obj)) return obj.map(redactObject);
+  if (typeof obj === "object") {
+    const out: Record<string, any> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (k === "secretKey" || k === "privateKey" || k === "seed") {
+        out[k] = "[REDACTED]";
+      } else {
+        out[k] = redactObject(v);
+      }
+    }
+    return out;
+  }
+  return redactValue(obj);
+}
+
+const logger = pino({
+  level: process.env.LOG_LEVEL || "info",
+  // keep path-based redaction for structured fields
+  redact: { paths: ["*.secretKey", "*.privateKey", "*.seed"], censor: "[REDACTED]" },
+  // ensure values (strings) that match Stellar secret pattern are redacted anywhere
+  formatters: {
+    log(obj: Record<string, any>) {
+      return redactObject(obj);
+    },
+  },
+});
+
+export { logger, redactObject, STELLAR_SECRET_REGEX };

--- a/backend/src/middleware/requestLogger.ts
+++ b/backend/src/middleware/requestLogger.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import crypto from "crypto";
+import { logger } from "../logger";
 
 declare global {
   namespace Express {
@@ -30,16 +31,8 @@ export function requestLogger(req: Request, res: Response, next: NextFunction) {
       duration: `${duration}ms`,
     };
 
-    // ✅ STEP 4: Make logs readable in development
-    if (process.env.NODE_ENV === "production") {
-      // Machine-readable (for logging systems)
-      console.log(JSON.stringify(logEntry));
-    } else {
-      // Human-readable (for local dev)
-      console.log(
-        `${req.method} ${req.originalUrl} ${res.statusCode} - ${duration}ms | id=${requestId}`
-      );
-    }
+    // ✅ STEP 4: Use structured logger with redaction
+    logger.info(logEntry, `${req.method} ${req.originalUrl} ${res.statusCode} - ${duration}ms | id=${requestId}`);
   });
 
   // ✅ STEP 5: Continue request


### PR DESCRIPTION


Closes #442 

## Checklist

- [ ] I kept the change focused on the related issue.
- [ ] I added or updated tests where useful.
- [ ] I updated documentation where behavior changed.
- [ ] I verified the app still builds or explained why verification was skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Logging and Secret Redaction" section to security guidelines documenting automatic redaction of sensitive values in server logs.

* **New Features**
  * Implemented automatic redaction of sensitive data (secret keys, tokens, private keys, and Stellar seed strings) in application logs.

* **Tests**
  * Added test coverage for secret redaction functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-stream/pull/482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->