### PR TITLE
feat: Implement draft recovery banner with autosave functionality

### DIFF
--- a/frontend/src/components/CreateStreamForm.tsx
+++ b/frontend/src/components/CreateStreamForm.tsx
@@ -116,7 +116,8 @@ export function CreateStreamForm({
 }: CreateStreamFormProps) {
   const [values, setValues, hasDraft, clearDraft] = useDraftAutosave<FormValues>(
     "stellar-stream:create-draft",
-    INITIAL_VALUES
+    INITIAL_VALUES,
+    2000 // Autosave every 2 seconds
   );
   const [allowedAssets, setAllowedAssets] = useState<string[]>([]);
   const [configFetchFailed, setConfigFetchFailed] = useState(false);
@@ -232,6 +233,32 @@ export function CreateStreamForm({
 
   return (
     <form onSubmit={handleSubmit} noValidate>
+      {hasDraft && (
+        <div
+          className="draft-recovery-banner"
+          role="status"
+          aria-live="polite"
+          aria-label="Draft recovered"
+        >
+          ✓ Your unsaved draft has been recovered. You can{" "}
+          <button
+            type="button"
+            className="draft-recovery-banner__discard-link"
+            onClick={() => {
+              if (window.confirm("Discard your unsaved stream draft?")) {
+                clearDraft();
+                setTouched({});
+                setSubmitAttempted(false);
+              }
+            }}
+            disabled={isSubmitting}
+          >
+            discard it
+          </button>{" "}
+          if you prefer to start over.
+        </div>
+      )}
+
       {parsedApiError && (
         <div className="api-error-box">
           <div className="api-error-box__title">{parsedApiError.title}</div>
@@ -533,22 +560,6 @@ export function CreateStreamForm({
         >
           {isSubmitting ? "Creating…" : "Create Stream"}
         </button>
-        {hasDraft && (
-          <button
-            type="button"
-            className="btn-ghost"
-            onClick={() => {
-              if (window.confirm("Discard your unsaved stream draft?")) {
-                clearDraft();
-                setTouched({});
-                setSubmitAttempted(false);
-              }
-            }}
-            disabled={isSubmitting}
-          >
-            Discard Draft
-          </button>
-        )}
       </div>
     </form>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -203,6 +203,43 @@ body {
   line-height: 1.5;
 }
 
+/* ── Draft recovery banner ────────────────────────────── */
+
+.draft-recovery-banner {
+  background: #f0fdf4;
+  border: 1.5px solid #bbf7d0;
+  border-radius: 8px;
+  padding: 0.65rem 0.8rem;
+  font-size: 0.88rem;
+  color: #166534;
+  line-height: 1.5;
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 0.85rem;
+}
+
+.draft-recovery-banner__discard-link {
+  background: none;
+  border: none;
+  color: #166534;
+  text-decoration: underline;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0;
+  font: inherit;
+}
+
+.draft-recovery-banner__discard-link:hover:not(:disabled) {
+  color: #15803d;
+}
+
+.draft-recovery-banner__discard-link:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* ── Global error banner (cancel failures, etc.) ───────── */
 
 .error-banner {


### PR DESCRIPTION
closes #393 
closes #394 
closes #410 
closes #395 

- Update debounce to 2 seconds - Currently using the default 500ms debounce
- Add draft recovery notification - Let users know their draft was recovered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic draft auto-save functionality now saves form progress at regular intervals during stream creation
  * Replaced discard draft button with inline "Draft recovered" banner that displays when a saved draft is detected
  * Draft discard action includes confirmation step and clears all form data and submission state

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-stream/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->