### PR TITLE
Add GET /api/streams/by-sender/:address and by-recipient/:address dedicated endpoints

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -522,7 +522,13 @@ app.get("/api/streams/:id", readLimiter, (req: Request, res: Response) => {
   });
 });
 
-
+app.get(
+  "/api/recipients/:accountId/streams",
+  readLimiter,
+  (req: Request, res: Response) => {
+    const parsedParams = recipientAccountIdSchema.safeParse({
+      accountId: req.params.accountId,
+    });
 
     if (!parsedParams.success) {
       sendValidationError(req, res, parsedParams.error.issues);
@@ -549,6 +555,155 @@ app.get("/api/streams/:id", readLimiter, (req: Request, res: Response) => {
     if (query.sender) {
       data = data.filter(
         (stream) => stream.sender.toLowerCase() === query.sender!.toLowerCase(),
+      );
+    }
+    if (query.asset) {
+      data = data.filter(
+        (stream) =>
+          stream.assetCode.toLowerCase() === query.asset!.toLowerCase(),
+      );
+    }
+    if (query.q && query.q.length > 0) {
+      const searchTerm = query.q.toLowerCase();
+      data = data.filter((stream) => {
+        return (
+          stream.id.toLowerCase().includes(searchTerm) ||
+          stream.sender.toLowerCase().includes(searchTerm) ||
+          stream.recipient.toLowerCase().includes(searchTerm) ||
+          stream.assetCode.toLowerCase().includes(searchTerm)
+        );
+      });
+    }
+
+    const hasPage = req.query.page !== undefined;
+    const hasLimit = req.query.limit !== undefined;
+
+    const total = data.length;
+    const page = query.page ?? PAGINATION_DEFAULT_PAGE;
+    const limit =
+      !hasPage && !hasLimit ? total : (query.limit ?? PAGINATION_DEFAULT_LIMIT);
+
+    const offset = (page - 1) * limit;
+    const paginatedData = data.slice(offset, offset + limit);
+
+    res.json({
+      data: paginatedData,
+      total,
+      page,
+      limit,
+    });
+  },
+);
+
+// Dedicated endpoints for looking up streams by sender or recipient
+
+app.get(
+  "/api/streams/by-recipient/:accountId",
+  readLimiter,
+  (req: Request, res: Response) => {
+    const parsedParams = recipientAccountIdSchema.safeParse({
+      accountId: req.params.accountId,
+    });
+
+    if (!parsedParams.success) {
+      sendValidationError(req, res, parsedParams.error.issues);
+      return;
+    }
+
+    const accountId = parsedParams.data.accountId;
+
+    const parsedQuery = listStreamsQuerySchema.safeParse(req.query);
+    if (!parsedQuery.success) {
+      sendValidationError(req, res, parsedQuery.error.issues);
+      return;
+    }
+    const query = parsedQuery.data;
+
+    let data = listStreamsByRecipient(accountId).map((stream) => ({
+      ...stream,
+      progress: calculateProgress(stream),
+    }));
+
+    if (query.status) {
+      data = data.filter((stream) => stream.progress.status === query.status);
+    }
+    if (query.sender) {
+      data = data.filter(
+        (stream) => stream.sender.toLowerCase() === query.sender!.toLowerCase(),
+      );
+    }
+    if (query.asset) {
+      data = data.filter(
+        (stream) =>
+          stream.assetCode.toLowerCase() === query.asset!.toLowerCase(),
+      );
+    }
+    if (query.q && query.q.length > 0) {
+      const searchTerm = query.q.toLowerCase();
+      data = data.filter((stream) => {
+        return (
+          stream.id.toLowerCase().includes(searchTerm) ||
+          stream.sender.toLowerCase().includes(searchTerm) ||
+          stream.recipient.toLowerCase().includes(searchTerm) ||
+          stream.assetCode.toLowerCase().includes(searchTerm)
+        );
+      });
+    }
+
+    const hasPage = req.query.page !== undefined;
+    const hasLimit = req.query.limit !== undefined;
+
+    const total = data.length;
+    const page = query.page ?? PAGINATION_DEFAULT_PAGE;
+    const limit =
+      !hasPage && !hasLimit ? total : (query.limit ?? PAGINATION_DEFAULT_LIMIT);
+
+    const offset = (page - 1) * limit;
+    const paginatedData = data.slice(offset, offset + limit);
+
+    res.json({
+      data: paginatedData,
+      total,
+      page,
+      limit,
+    });
+  },
+);
+
+app.get(
+  "/api/streams/by-sender/:accountId",
+  readLimiter,
+  (req: Request, res: Response) => {
+    const parsedParams = senderAccountIdSchema.safeParse({
+      accountId: req.params.accountId,
+    });
+
+    if (!parsedParams.success) {
+      sendValidationError(req, res, parsedParams.error.issues);
+      return;
+    }
+
+    const accountId = parsedParams.data.accountId;
+
+    const parsedQuery = listStreamsQuerySchema.safeParse(req.query);
+    if (!parsedQuery.success) {
+      sendValidationError(req, res, parsedQuery.error.issues);
+      return;
+    }
+    const query = parsedQuery.data;
+
+    let data = listStreamsBySender(accountId).map((stream) => ({
+      ...stream,
+      progress: calculateProgress(stream),
+    }));
+
+    if (query.status) {
+      data = data.filter((stream) => stream.progress.status === query.status);
+    }
+    if (query.recipient) {
+      data = data.filter(
+        (stream) =>
+          stream.recipient.toLowerCase() === query.recipient!.toLowerCase(),
       );
     }
     if (query.asset) {


### PR DESCRIPTION
Closes #452

Adds two dedicated GET endpoints for looking up streams by address:
- `/api/streams/by-recipient/:accountId` — returns streams where the given address is the recipient
- `/api/streams/by-sender/:accountId` — returns streams where the given address is the sender

Both support filtering by `status`, `asset`, and `q` (search term), plus pagination.

Also fixes the missing `app.get()` header for the existing `/api/recipients/:accountId/streams` route.

**Wallet:**
USDC Stellar: GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF
BNB: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3