### PR TITLE
Add StreamsTable column toggle for showing/hiding optional columns

### DIFF
--- a/frontend/src/components/ColumnToggle.tsx
+++ b/frontend/src/components/ColumnToggle.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+
+export interface ColumnConfig {
+  key: string;
+  label: string;
+  defaultVisible: boolean;
+}
+
+interface ColumnToggleProps {
+  columns: ColumnConfig[];
+  visibleColumns: Set<string>;
+  onToggle: (key: string) => void;
+}
+
+export function ColumnToggle({ columns, visibleColumns, onToggle }: ColumnToggleProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="column-toggle" style={{ position: "relative" }}>
+      <button
+        type="button"
+        className="btn-ghost"
+        onClick={() => setOpen(!open)}
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        ⚙ Columns
+      </button>
+      {open && (
+        <div
+          className="column-toggle__dropdown"
+          style={{
+            position: "absolute",
+            top: "100%",
+            right: 0,
+            zIndex: 10,
+            background: "var(--color-background)",
+            border: "1px solid var(--color-border)",
+            borderRadius: "6px",
+            padding: "0.5rem",
+            minWidth: "180px",
+            boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+          }}
+        >
+          {columns.map((col) => (
+            <label
+              key={col.key}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5rem",
+                padding: "0.25rem 0",
+                cursor: "pointer",
+                whiteSpace: "nowrap",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={visibleColumns.has(col.key)}
+                onChange={() => onToggle(col.key)}
+              />
+              {col.label}
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #458

Adds a reusable ColumnToggle dropdown component that:
- Renders a Columns button that opens a dropdown with checkbox toggles
- Each column can be shown or hidden
- Designed to integrate into StreamsTable for controlling visibility of columns like amount, progress, and health badges
- Accessible with aria-haspopup, aria-expanded, and label associations

Usage:
```tsx
<ColumnToggle columns={columns} visibleColumns={visibleCols} onToggle={toggleCol} />
```

**Wallet:**
USDC Stellar: GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF
BNB: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3