### PR TITLE
devops: add Prometheus scrape config and metrics documentation

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,1 @@
+# Prometheus metrics endpoint exposed at /api/metrics

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'stellar-stream-backend'
+    static_configs:
+      - targets: ['localhost:3000']
+    metrics_path: '/api/metrics'


### PR DESCRIPTION
Closes #447

Adds `prometheus.yml` scrape configuration and basic metrics documentation.

**Wallet:**
- Stellar (USDC): `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`
- BNB (BSC): `0x6851F2cCD4C4EA991734FAA83c027A909f2703f3`