### PR TITLE
devops: add weekly load test workflow for backend API

### DIFF
--- a/.github/workflows/weekly-load-test.yml
+++ b/.github/workflows/weekly-load-test.yml
@@ -1,0 +1,24 @@
+name: Weekly Load Test
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Every Monday at 6 AM UTC
+  workflow_dispatch:
+
+jobs:
+  load-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install autocannon
+        run: npm install -g autocannon
+      - name: Run load test
+        run: |
+          autocannon --connections 50 --pipeline 10 --duration 60 \
+            ${{ secrets.STAGING_URL }}/api/health \
+            ${{ secrets.STAGING_URL }}/api/streams
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-test-results
+          path: ./*.txt


### PR DESCRIPTION
Closes #426

Adds GitHub Actions workflow for weekly load testing with autocannon against the staging environment.

**Wallet:**
- Stellar (USDC): `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`
- BNB (BSC): `0x6851F2cCD4C4EA991734FAA83c027A909f2703f3`