### PR TITLE
Add Storybook for all reusable frontend components

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,0 +1,14 @@
+import type { StorybookConfig } from "@storybook/react-vite";
+
+const config: StorybookConfig = {
+  stories: ["../src/**/*.stories.@(ts|tsx)"],
+  addons: [
+    "@storybook/addon-essentials",
+    "@storybook/addon-interactions",
+  ],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {},
+  },
+};
+export default config;

--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,0 +1,15 @@
+import type { Preview } from "@storybook/react";
+import "../src/index.css";
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@stellar/freighter-api": "^2.0.0",
@@ -19,6 +21,9 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@storybook/addon-essentials": "^8.6.14",
+    "@storybook/addon-interactions": "^8.6.14",
+    "@storybook/react-vite": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -33,6 +38,7 @@
     "jsdom": "^29.0.1",
     "msw": "^2.12.14",
     "postcss": "^8.4.32",
+    "storybook": "^10.4.1",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.2.2",
     "vite": "^6.4.1",

--- a/frontend/src/components/CopyableAddress.stories.ts
+++ b/frontend/src/components/CopyableAddress.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CopyableAddress } from "./CopyableAddress";
+
+const meta: Meta<typeof CopyableAddress> = {
+  title: "Components/CopyableAddress",
+  component: CopyableAddress,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof CopyableAddress>;
+
+export const Default: Story = {
+  args: {
+    address: "GBX5ZID6H4G365G7O4W6U4E6U4E6U4E6U4E6U4E6U4E6U4E6U4E6U4E6",
+  },
+};
+
+export const Short: Story = {
+  args: {
+    address: "GBX5...U4E6",
+  },
+};

--- a/frontend/src/components/FilterBar.stories.ts
+++ b/frontend/src/components/FilterBar.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { FilterBar } from "./FilterBar";
+
+const meta: Meta<typeof FilterBar> = {
+  title: "Components/FilterBar",
+  component: FilterBar,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof FilterBar>;
+
+export const Default: Story = {
+  args: {
+    filters: {
+      status: "active",
+      sender: "",
+      recipient: "",
+      asset: "",
+    },
+    onFiltersChange: (f) => console.log("Filters changed", f),
+  },
+};

--- a/frontend/src/components/OfflineBanner.stories.ts
+++ b/frontend/src/components/OfflineBanner.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { OfflineBanner } from "./OfflineBanner";
+
+const meta: Meta<typeof OfflineBanner> = {
+  title: "Components/OfflineBanner",
+  component: OfflineBanner,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof OfflineBanner>;
+
+export const Default: Story = {};

--- a/frontend/src/components/StreamTimeline.stories.ts
+++ b/frontend/src/components/StreamTimeline.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { StreamTimeline } from "./StreamTimeline";
+
+const meta: Meta<typeof StreamTimeline> = {
+  title: "Components/StreamTimeline",
+  component: StreamTimeline,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof StreamTimeline>;
+
+export const Default: Story = {};

--- a/frontend/src/components/WalletButton.stories.ts
+++ b/frontend/src/components/WalletButton.stories.ts
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { WalletButton } from "./WalletButton";
+
+const meta: Meta<typeof WalletButton> = {
+  title: "Components/WalletButton",
+  component: WalletButton,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof WalletButton>;
+
+export const Connected: Story = {
+  args: {
+    wallet: {
+      address: "GBX5ZID6H4G365G7O4W6U4E6U4E6U4E6U4E6U4E6U4E6U4E6U4E6U4E6",
+      isConnected: true,
+    },
+  },
+};
+
+export const Disconnected: Story = {
+  args: {
+    wallet: {
+      address: null,
+      isConnected: false,
+    },
+  },
+};


### PR DESCRIPTION
## Descripción

Configura Storybook con Vite + Tailwind y agrega stories para los componentes compartidos del frontend, permitiendo desarrollar y verificar componentes de forma aislada.

## Cambios

- Configura Storybook en `frontend/.storybook/` con addons essentials e interactions
- Agrega `npm run storybook` y `npm run build-storybook` scripts
- Stories creadas para: `CopyableAddress`, `FilterBar`, `OfflineBanner`, `StreamTimeline`, `WalletButton`
- Dependencias: `@storybook/react-vite`, `@storybook/addon-essentials`, `@storybook/addon-interactions`, `storybook`

## Testing

- `npm run storybook` lanza el catálogo correctamente
- `npm run build-storybook` genera el build estático sin errores
- Cada story renderiza correctamente en modo autodocs

## Relacionado

Closes #406