### PR TITLE
Add docker-compose health checks for frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,3 +47,9 @@ services:
       backend:
         condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s


### PR DESCRIPTION
## Descripción

Agrega healthcheck al servicio frontend en docker-compose.yml para que Docker pueda monitorear el estado del contenedor.

## Cambios

- Agrega bloque `healthcheck` al servicio `frontend` en `docker-compose.yml`:
  - Test: `curl -f http://localhost:3000`
  - Interval: 10s, Timeout: 5s, Retries: 3, Start period: 15s
- El backend ya tenía healthcheck, esto completa la cobertura para frontend también

## Testing

- `docker compose up` muestra el estado healthy del frontend después del start_period
- `docker compose ps` confirma estado `healthy`

## Relacionado

Closes #414