### PR TITLE
Add streamStore unit tests for calculateProgress edge cases

### DIFF
--- a/backend/src/services/streamStore.progress.test.ts
+++ b/backend/src/services/streamStore.progress.test.ts
@@ -367,4 +367,338 @@ describe("calculateProgress", () => {
       expect(progress.percentComplete).toBeGreaterThan(0);
     });
   });
+
+  describe("Boundary conditions", () => {
+    it("should handle exactly at start time (t === startAt)", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 1000,
+      });
+
+      const currentTime = 1000000; // Exactly at start time
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("active");
+      expect(progress.elapsedSeconds).toBe(0);
+      expect(progress.vestedAmount).toBe(0);
+      expect(progress.percentComplete).toBe(0);
+    });
+
+    it("should handle exactly at end time (t === end)", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 1000,
+      });
+
+      const currentTime = 1003600; // Exactly at end time
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("completed");
+      expect(progress.elapsedSeconds).toBe(3600);
+      expect(progress.vestedAmount).toBe(1000);
+      expect(progress.percentComplete).toBe(100);
+    });
+
+    it("should handle one second before completion", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 3600, // 1 per second
+      });
+
+      const currentTime = 1003599; // 1 second before end
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("active");
+      expect(progress.elapsedSeconds).toBe(3599);
+      expect(progress.vestedAmount).toBe(3599);
+      expect(progress.percentComplete).toBeCloseTo(99.97, 1);
+    });
+
+    it("should handle one second after start", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 3600,
+      });
+
+      const currentTime = 1000001; // 1 second after start
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("active");
+      expect(progress.elapsedSeconds).toBe(1);
+      expect(progress.vestedAmount).toBe(1);
+      expect(progress.percentComplete).toBeCloseTo(0.03, 2);
+    });
+  });
+
+  describe("Paused duration edge cases", () => {
+    it("should handle active stream with existing pausedDuration but not currently paused", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 1000,
+        pausedDuration: 600, // Was paused for 10 minutes previously
+        // pausedAt is NOT set — stream is currently active but has historical pause time
+      });
+
+      const currentTime = 1002700; // 45 min after start, but 10 min was paused
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("active");
+      // streamEnd = 1000000+3600+600 = 1004200, rawElapsed = 1002700-1000000 = 2700, elapsed = 2700-600 = 2100
+      expect(progress.elapsedSeconds).toBe(2100); // 45min - 10min pause = 35min = 2100s
+      expect(progress.vestedAmount).toBeCloseTo(583.33, 1); // 2100/3600 * 1000 ≈ 583.33
+      expect(progress.percentComplete).toBeCloseTo(58.33, 1);
+    });
+
+    it("should handle paused stream at exact moment of pause", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 1000,
+        pausedDuration: 0,
+        pausedAt: 1001800, // Paused at 30 min mark
+      });
+
+      const currentTime = 1001800; // Exactly at pause moment (30min after start)
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("paused");
+      // effectiveAt = min(1001800,1001800) = 1001800, rawElapsed = 1001800-1000000 = 1800, elapsed = 1800-0 = 1800
+      expect(progress.elapsedSeconds).toBe(1800); // 30 min effective
+      expect(progress.vestedAmount).toBe(500); // 1800/3600 * 1000
+    });
+
+    it("should handle stream paused then resumed then paused again (two pauses)", () => {
+      // This simulates: paused at 1001200 (resumed later), resumed at 1001800, 
+      // then paused again at 1002400. Total pausedDuration = 600 + current pause time.
+      // Still currently paused at currentTime.
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 1000,
+        pausedDuration: 600, // 10 minutes from first pause
+        pausedAt: 1002400, // Currently paused again at 40 min mark
+      });
+
+      const currentTime = 1003000; // 50 min after start, currently paused
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("paused");
+      // Effective elapsed = min(at, pausedAt) - startAt - pausedDuration
+      // = 1002400 - 1000000 - 600 = 1800
+      expect(progress.elapsedSeconds).toBe(1800);
+      expect(progress.vestedAmount).toBe(500); // Halfway
+      expect(progress.percentComplete).toBe(50);
+    });
+
+    it("should handle completed stream that was paused during its lifecycle", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 1000,
+        pausedDuration: 600, // Was paused for 10 minutes
+        completedAt: 1004200, // Completed at the delayed end
+      });
+
+      const currentTime = 1005000; // Well after completion
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("completed");
+      // streamEnd = 1000000+3600+600 = 1004200, rawElapsed = min(1005000,1004200)-1000000 = 4200, elapsed = 4200-600 = 3600
+      expect(progress.elapsedSeconds).toBe(3600); // Full effective duration
+      expect(progress.vestedAmount).toBe(1000);
+      expect(progress.percentComplete).toBe(100);
+    });
+  });
+
+  describe("Canceled stream advanced cases", () => {
+    it("should handle canceled at exact start time (no vesting)", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 1000,
+        canceledAt: 1000000, // Canceled exactly when it should start
+      });
+
+      const currentTime = 1003600;
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("canceled");
+      expect(progress.elapsedSeconds).toBe(0);
+      expect(progress.vestedAmount).toBe(0);
+      expect(progress.percentComplete).toBe(0);
+    });
+
+    it("should handle canceled with paused duration", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 1000,
+        pausedDuration: 600, // 10 min paused
+        canceledAt: 1003000, // Canceled at 50 min mark (40 min effective)
+      });
+
+      const currentTime = 1005000;
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("canceled");
+      expect(progress.elapsedSeconds).toBe(2400); // 50min - 10min = 40 min effective
+      expect(progress.vestedAmount).toBeCloseTo(666.67, 1); // 40/60 * 1000
+      expect(progress.percentComplete).toBeCloseTo(66.67, 1);
+      expect(progress.remainingAmount).toBeCloseTo(333.33, 1);
+    });
+
+    it("should handle canceled stream with no duration (instant stream)", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 0,
+        totalAmount: 1000,
+        canceledAt: 999000, // Canceled before it could start
+      });
+
+      const currentTime = 1005000;
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("canceled");
+      expect(progress.vestedAmount).toBe(0);
+      expect(progress.percentComplete).toBe(0);
+      expect(progress.remainingAmount).toBe(1000);
+    });
+  });
+
+  describe("Large values and edge inputs", () => {
+    it("should handle very large amounts", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 1000000000, // 1 billion
+      });
+
+      const currentTime = 1001800; // Halfway
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("active");
+      expect(progress.vestedAmount).toBe(500000000);
+      expect(progress.remainingAmount).toBe(500000000);
+      expect(progress.percentComplete).toBe(50);
+    });
+
+    it("should handle very short duration stream (1 second)", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 1,
+        totalAmount: 100,
+      });
+
+      const currentTime = 1000000; // At start
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("active");
+      expect(progress.vestedAmount).toBe(0);
+      expect(progress.percentComplete).toBe(0);
+    });
+
+    it("should handle very short duration stream (1 second) after completion", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 1,
+        totalAmount: 100,
+      });
+
+      const currentTime = 1000001; // After 1 second
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("completed");
+      expect(progress.vestedAmount).toBe(100);
+      expect(progress.percentComplete).toBe(100);
+    });
+
+    it("should handle very large duration (years)", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 31536000, // 1 year
+        totalAmount: 1000,
+      });
+
+      const currentTime = 1000001; // 1 second in
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("active");
+      expect(progress.vestedAmount).toBeCloseTo(0.00003, 4);
+      expect(progress.percentComplete).toBeCloseTo(0.000003, 6);
+    });
+  });
+
+  describe("computeStatus edge cases", () => {
+    it("should return scheduled when at is before startAt even with pausedDuration", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 1000,
+        pausedDuration: 300,
+      });
+
+      const currentTime = 999999; // Before start
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("scheduled");
+      expect(progress.vestedAmount).toBe(0);
+      expect(progress.percentComplete).toBe(0);
+    });
+
+    it("should handle both canceledAt and completedAt set (canceled takes priority)", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 1000,
+        canceledAt: 1001800, // Canceled at 30 min
+        completedAt: 1003600, // Would have completed
+      });
+
+      const currentTime = 1005000;
+      const progress = calculateProgress(stream, currentTime);
+
+      // canceledAt takes priority over completedAt per computeStatus
+      expect(progress.status).toBe("canceled");
+      expect(progress.vestedAmount).toBe(500); // Half vested at cancellation
+      expect(progress.percentComplete).toBe(50);
+    });
+
+    it("should handle completedAt set with no canceledAt (graceful completion)", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 1000,
+        completedAt: 1003600, // Normal completion
+      });
+
+      const currentTime = 1005000;
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("completed");
+      expect(progress.vestedAmount).toBe(1000);
+      expect(progress.percentComplete).toBe(100);
+    });
+
+    it("should return paused status when pausedAt is set but not canceled or completed", () => {
+      const stream = createBaseStream({
+        startAt: 1000000,
+        durationSeconds: 3600,
+        totalAmount: 1000,
+        pausedAt: 1001800, // Currently paused at 30 min
+        pausedDuration: 0,
+      });
+
+      const currentTime = 1002000; // Still paused
+      const progress = calculateProgress(stream, currentTime);
+
+      expect(progress.status).toBe("paused");
+      // Since we check canceledAt first, then completedAt, then pausedAt in computeStatus
+      // And pausedAt is set, it should be paused regardless of time
+    });
+  });
 });

--- a/backend/src/services/streamStore.ts
+++ b/backend/src/services/streamStore.ts
@@ -376,18 +376,25 @@ export function calculateProgress(
   stream: StreamRecord,
   at = nowInSeconds(),
 ): StreamProgress {
+  const streamEnd = stream.startAt + stream.durationSeconds + stream.pausedDuration;
 
-  }
-
-  const streamEnd = stream.startAt + stream.durationSeconds;
+  // Calculate effective duration cutoff for canceled/completed streams
+  const effectiveEnd =
+    stream.canceledAt !== undefined
+      ? Math.min(stream.canceledAt, streamEnd)
+      : streamEnd;
 
   // When paused, vesting is frozen at the moment of pause.
   const effectiveAt =
     stream.pausedAt !== undefined ? Math.min(at, stream.pausedAt) : at;
 
+  // Raw elapsed time (including paused time), then subtract paused duration
+  const rawElapsed = Math.max(0, Math.min(effectiveAt, effectiveEnd) - stream.startAt);
+  const elapsed = Math.max(0, rawElapsed - stream.pausedDuration);
 
-
-  const ratio = Math.min(1, elapsed / stream.durationSeconds);
+  const ratio = stream.durationSeconds > 0
+    ? Math.min(1, elapsed / stream.durationSeconds)
+    : (stream.canceledAt !== undefined ? 0 : 1);
   const vestedAmount = stream.totalAmount * ratio;
 
   return {


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for `streamStore.calculateProgress` covering all `StreamStatus` values and boundary conditions.

## Related Issues

Closes #465

## Test Coverage

### Scheduled
- startAt in future → percentComplete == 0

### Active  
- Midstream → linear percentComplete
- Exactly at start time (boundary)
- One second after start (boundary)
- One second before completion (boundary)

### Paused
- Vested frozen at pause timestamp
- Paused at exact moment of pause
- Multiple pause scenarios (paused → resumed → paused again)
- Active stream with historical pausedDuration (not currently paused)

### Completed
- percentComplete == 100, vestedAmount == totalAmount
- Exactly at end time (boundary)
- Completed stream with pausedDuration during lifecycle

### Canceled
- Uses canceledAt as vesting cutoff
- Canceled at exact start time (no vesting)
- Canceled with paused duration
- Canceled stream with zero duration
- Canceled before stream start
- Canceled after natural end
- CanceledAt + completedAt both set (canceled takes priority)

### Additional
- Very large amounts
- Very short duration (1 second)
- Very large duration (years)
- Zero amount stream
- Zero duration stream
- Fractional amounts and numerical precision
- Rate per second calculation for various amounts/durations

## Bug Fix

Also fixes a bug in `calculateProgress` where the function body was empty due to merge conflicts — missing `elapsed` variable calculation and `effectiveEnd` handling for canceled streams.

## Wallet

USDC Stellar: GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF
BNB/BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3