### PR TITLE
Add EmptyState for zero-stream filter results and wire clear filter /…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -301,14 +301,22 @@ function App() {
           </section>
 
           <section className="layout-grid">
-            <CreateStreamForm
-              onCreate={handleCreate}
-              apiError={formError}
-              walletAddress={wallet.address}
-            />
+            <div id="create-stream-section">
+              <CreateStreamForm
+                onCreate={handleCreate}
+                apiError={formError}
+                walletAddress={wallet.address}
+              />
+            </div>
             <StreamsTable
               streams={filteredStreams}
               filters={tableFilters}
+              totalStreamCount={streams.length}
+              onCreateStream={() =>
+                document
+                  .getElementById("create-stream-section")
+                  ?.scrollIntoView({ behavior: "smooth" })
+              }
               onFiltersChange={(next) => {
                 setFilter("status", next.status ?? defaultStreamFilters.status);
                 setFilter("sender", next.sender ?? defaultStreamFilters.sender);

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { ListStreamsFilters } from "../services/api";
+
+interface EmptyStateProps {
+  filters: ListStreamsFilters;
+  onClearFilters: () => void;
+  onCreateStream?: () => void;
+  hasAnyStreams: boolean;
+}
+
+export function EmptyState({
+  filters,
+  onClearFilters,
+  onCreateStream,
+  hasAnyStreams,
+}: EmptyStateProps) {
+  // Determine which filter is active to show contextual message
+  const getEmptyMessage = (): string => {
+    if (filters.status) {
+      const statusMessages: Record<string, string> = {
+        active: "No active streams",
+        scheduled: "No scheduled streams",
+        completed: "No completed streams",
+        canceled: "No canceled streams",
+      };
+      return statusMessages[filters.status] || `No streams with status "${filters.status}"`;
+    }
+    
+    if (filters.sender) {
+      return "No streams from this sender";
+    }
+    
+    if (filters.recipient) {
+      return "No streams to this recipient";
+    }
+    
+    if (filters.asset) {
+      return `No streams with asset "${filters.asset}"`;
+    }
+    
+    if (filters.q) {
+      return "No streams match your search";
+    }
+    
+    // No filters active
+    return hasAnyStreams ? "No streams match your filters" : "No streams yet";
+  };
+
+  const hasActiveFilters = Object.values(filters).some(
+    (value) => value && value.trim() !== ""
+  );
+
+  return (
+    <div className="empty-state" style={{ textAlign: "center", padding: "3rem 1rem" }}>
+      <div style={{ fontSize: "3rem", marginBottom: "1rem" }}>📭</div>
+      <h3 style={{ marginBottom: "0.5rem", color: "var(--color-text-primary)" }}>
+        {getEmptyMessage()}
+      </h3>
+      <p className="muted" style={{ marginBottom: "1.5rem", fontSize: "0.9rem" }}>
+        {hasActiveFilters
+          ? "Try adjusting your filters or clear them to see all streams."
+          : "Create your first stream to get started."}
+      </p>
+      <div style={{ display: "flex", gap: "0.75rem", justifyContent: "center", flexWrap: "wrap" }}>
+        {hasActiveFilters && (
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={onClearFilters}
+            style={{ fontSize: "0.9rem" }}
+          >
+            Clear Filters
+          </button>
+        )}
+        {!hasAnyStreams && onCreateStream && (
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={onCreateStream}
+            style={{ fontSize: "0.9rem" }}
+          >
+            Create Stream
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/StreamsTable.test.tsx
+++ b/frontend/src/components/StreamsTable.test.tsx
@@ -135,7 +135,46 @@ describe('StreamsTable Component', () => {
   it('renders a helpful message for empty streams array', () => {
     render(<StreamsTable {...defaultProps} streams={[]} />);
     
-    expect(screen.getByText(/no streams match your filters/i)).toBeInTheDocument();
+    expect(screen.getByText(/no streams yet/i)).toBeInTheDocument();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('renders EmptyState for filtered empty results and clears filters', () => {
+    const onFiltersChange = vi.fn();
+    render(
+      <StreamsTable
+        {...defaultProps}
+        streams={[]}
+        filters={{ status: 'active' }}
+        onFiltersChange={onFiltersChange}
+        totalStreamCount={4}
+      />
+    );
+
+    expect(screen.getByText(/no active streams/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /clear filters/i }));
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      status: '',
+      sender: '',
+      recipient: '',
+      asset: '',
+      q: '',
+    });
+  });
+
+  it('shows Create Stream button when there are no streams at all', () => {
+    const onCreateStream = vi.fn();
+    render(
+      <StreamsTable
+        {...defaultProps}
+        streams={[]}
+        onCreateStream={onCreateStream}
+      />
+    );
+
+    const createButton = screen.getByRole('button', { name: /create stream/i });
+    expect(createButton).toBeInTheDocument();
+    fireEvent.click(createButton);
+    expect(onCreateStream).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/StreamsTable.tsx
+++ b/frontend/src/components/StreamsTable.tsx
@@ -5,6 +5,7 @@ import { CopyableAddress } from "./CopyableAddress";
 import { StreamTimeline } from "./StreamTimeline";
 import { getHealthBadges } from "../utils/streamHealthBadges";
 import { FilterBar } from "./FilterBar";
+import { EmptyState } from "./EmptyState";
 
 interface StreamsTableProps {
   streams: Stream[];
@@ -17,6 +18,14 @@ interface StreamsTableProps {
    * Receives the stream AND the button ref so the modal can return focus.
    */
   onEditStartTime: (stream: Stream, triggerRef: RefObject<HTMLButtonElement | null>) => void;
+  /**
+   * Total count of all streams (before filtering) to determine if no streams exist at all.
+   */
+  totalStreamCount?: number;
+  /**
+   * Optional callback for creating a new stream (shown when no streams exist at all).
+   */
+  onCreateStream?: () => void;
 }
 
 function statusClass(status: Stream["progress"]["status"]): string {
@@ -40,12 +49,24 @@ export function StreamsTable({
   onCancel,
   onEditStartTime,
   onOpenStream,
+  totalStreamCount = 0,
+  onCreateStream,
 }: StreamsTableProps) {
   const [expandedStreamId, setExpandedStreamId] = useState<string | null>(null);
   const exportUrl = useMemo(() => getExportCsvUrl(filters as Record<string, string>), [filters]);
 
   const toggleTimeline = (streamId: string) => {
     setExpandedStreamId((prev) => (prev === streamId ? null : streamId));
+  };
+
+  const handleClearFilters = () => {
+    onFiltersChange({
+      status: "",
+      sender: "",
+      recipient: "",
+      asset: "",
+      q: "",
+    });
   };
 
   return (
@@ -66,7 +87,12 @@ export function StreamsTable({
       </div>
 
       {streams.length === 0 ? (
-        <p className="muted">No streams match your filters.</p>
+        <EmptyState
+          filters={filters}
+          onClearFilters={handleClearFilters}
+          hasAnyStreams={totalStreamCount > 0}
+          onCreateStream={onCreateStream}
+        />
       ) : (
         <div className="table-wrap">
           <table>


### PR DESCRIPTION
… create stream actions

## What changed

-

## Testing done

-

## Related issues

Closes #

## Checklist

- [ ] I kept the change focused on the related issue.
- [ ] I added or updated tests where useful.
- [ ] I updated documentation where behavior changed.
- [ ] I verified the app still builds or explained why verification was skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced empty state with contextual messaging that adapts based on your active filters
  * Quick access to "Clear Filters" button in empty state for fast filter removal
  * Direct "Create Stream" option available in empty state when no streams exist
  * Improved navigation with smooth scrolling to the create stream section

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-stream/pull/524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->