### PR TITLE
Feature/asset expansion and integration tests

### DIFF
--- a/backend/src/assets.test.ts
+++ b/backend/src/assets.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+
+describe("Assets API Configuration", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("should respect ALLOWED_ASSETS environment variable override and normalize", async () => {
+    vi.stubEnv("ALLOWED_ASSETS", "yusd, euRo, testCoin ");
+    
+    // Dynamically import app so it picks up the stubbed environment variable
+    const { app } = await import("./index");
+    
+    const response = await request(app).get("/api/assets");
+    
+    expect(response.status).toBe(200);
+    expect(response.body.data).toEqual(["YUSD", "EURO", "TESTCOIN"]);
+  });
+});

--- a/backend/src/integration.test.ts
+++ b/backend/src/integration.test.ts
@@ -275,6 +275,7 @@ describe("Backend Integration Tests", () => {
         expect(response.status).toBe(200);
         expect(response.body.data).toHaveLength(1);
         expect(response.body.data[0].sender).toBe(mockStream.sender);
+        expect(response.body.data[0].progress).toBeDefined();
       });
 
       it("should filter sender streams by status", async () => {

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -213,7 +213,13 @@ impl StellarStreamContract {
             panic!("recipients must not be empty");
         }
 
-        let token_client = TokenClient::new(&env, &token);
+        let is_native = token.to_string() == String::from_str(&env, NATIVE_SENTINEL);
+        let actual_token = if is_native {
+            env.storage().instance().get(&DataKey::NativeToken).unwrap_or_else(|| panic!("not initialized"))
+        } else {
+            token.clone()
+        };
+        let token_client = TokenClient::new(&env, &actual_token);
         let sender_balance = token_client.balance(&sender);
         if sender_balance < total_amount {
             panic!("insufficient sender balance");


### PR DESCRIPTION
## Summary

Implements three related improvements for StellarStream observability, accessibility, and user feedback:

- **#404** — Integrates `axe-core` into Vitest for `StreamsTable`, `StreamDetailDrawer`, `CreateStreamForm`, and `RecipientDashboard`, fixes violations (labels, progressbars, table semantics), and restores corrupted frontend/backend files needed for a clean build.
- **#447** — Exposes `GET /api/metrics` in Prometheus format with default Node/process metrics plus `streams_active`, `indexer_poll_duration_seconds`, `websocket_connections`, and `claim_total`. Commits `docs/grafana-dashboard.json` for Railway/Grafana scraping. Metrics endpoint is not rate-limited.
- **#402** — Standardizes success/error toasts for all async stream actions (create, claim, pause, resume, cancel) through `useToast`, including Freighter signing rejection messaging, 5-second auto-dismiss, manual dismiss, and `aria-live="polite"` announcements.

## Changes

### Frontend
- `vitest-axe` + `axe-core` a11y test suite (`*.a11y.test.tsx`)
- `useToast` auto-dismiss → 5s; global toast CSS
- `RecipientDashboard` uses shared toast stack instead of inline claim toasts
- `formatActionError()` helper for API + Freighter errors
- Restored complete `App.tsx` with pause/resume handlers and aligned toast copy

### Backend
- `prom-client` registry with `collectDefaultMetrics()` and custom gauges/counters/histograms
- `metricsRefresh.ts` updates `streams_active` on scrape
- Indexer records `indexer_poll_duration_seconds`; claim route increments `claim_total`
- Fixed syntax/route corruption in `index.ts` (streams, recipients, senders, auth, start-time)

### Docs
- `docs/grafana-dashboard.json` — panels for streams, WebSocket connections, indexer lag, claims, CPU, memory, event loop

## Test plan

- [x] `cd frontend && npm test -- --run` (174 tests)
- [x] `cd backend && npx vitest run src/metrics.test.ts` (2 tests)
- [ ] Manual: `GET /api/metrics` returns Prometheus text; scrape from Grafana using committed dashboard JSON
- [ ] Manual: Create / pause / resume / cancel stream — verify success toasts
- [ ] Manual: Reject Freighter signature — verify rejection toast
- [ ] Manual: Claim from recipient dashboard — verify “Claim submitted” toast
- [ ] Manual: Keyboard-tab through stream table actions and form fields

## Notes

- `websocket_connections` is exported as a gauge (defaults to 0 until a WebSocket server increments it).
- Removed empty/corrupt `IssueBacklog.test.tsx` that blocked the Vitest suite.

Closes #404 
Closes #402 
Closes #447 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for Assets API configuration and environment variable normalization.
  * Added assertion for stream progress field validation in API responses.

* **Bug Fixes**
  * Native tokens now properly supported in split stream creation, consistent with regular stream functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-stream/pull/528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->