### PR TITLE
Add create stream fee preview

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -49,6 +49,7 @@ import {
   listStreamsByRecipient,
   listStreamsBySender,
   pauseStream,
+  estimateCreateStreamFee,
   refreshStreamStatuses,
   resumeStream,
   StreamStatus,
@@ -680,6 +681,41 @@ app.post("/api/auth/token", async (req: Request, res: Response) => {
 
 // POST /api/auth/refresh — accepts a valid Bearer JWT, returns a new one with fresh 24h expiry
 app.post("/api/auth/refresh", refreshToken);
+
+app.post(
+  "/api/streams/fee-estimate",
+  mutationLimiter,
+  authMiddleware,
+  async (req: Request, res: Response) => {
+    const parsedBody = createStreamPayloadWithAllowedAssetsSchema(
+      ALLOWED_ASSETS,
+    ).safeParse(req.body);
+    if (!parsedBody.success) {
+      sendValidationError(req, res, parsedBody.error.issues);
+      return;
+    }
+
+    try {
+      const estimate = await estimateCreateStreamFee(parsedBody.data);
+      res.json({ data: estimate });
+    } catch (error: any) {
+      console.error("Failed to estimate stream creation fee:", error);
+      const normalizedError = normalizeUnknownApiError(
+        error,
+        "Failed to estimate network fee.",
+      );
+      sendApiError(
+        req,
+        res,
+        normalizedError.statusCode,
+        normalizedError.message,
+        {
+          code: normalizedError.code ?? "INTERNAL_ERROR",
+        },
+      );
+    }
+  },
+);
 
 app.post(
   "/api/streams",

--- a/backend/src/services/streamStore.ts
+++ b/backend/src/services/streamStore.ts
@@ -28,6 +28,11 @@ export interface StreamInput {
   startAt?: number;
 }
 
+export interface StreamFeeEstimate {
+  feeStroops: number;
+  feeXlm: string;
+}
+
 export interface StreamRecord {
   id: string;
   sender: string;
@@ -260,6 +265,41 @@ async function simulateContractCall(
     .build();
 
   return rpcServer.simulateTransaction(tx);
+}
+
+const STROOPS_PER_XLM = 10_000_000;
+
+function formatStroopsAsXlm(stroops: number): string {
+  return (stroops / STROOPS_PER_XLM).toFixed(7);
+}
+
+function createStreamOperation(contractId: string, input: StreamInput, startAt: number) {
+  const endAt = startAt + input.durationSeconds;
+  const fakeToken = contractId;
+
+  return new Contract(contractId).call(
+    "create_stream",
+    new Address(input.sender).toScVal(),
+    new Address(input.recipient).toScVal(),
+    new Address(fakeToken).toScVal(),
+    nativeToScVal(input.totalAmount, { type: "i128" }),
+    nativeToScVal(startAt, { type: "u64" }),
+    nativeToScVal(endAt, { type: "u64" }),
+  );
+}
+
+function readSimulationFeeStroops(simRes: rpc.Api.SimulateTransactionResponse): number {
+  const rawFee =
+    (simRes as any).minResourceFee ??
+    (simRes as any).feeCharged ??
+    (simRes as any).result?.minResourceFee;
+  const feeStroops = Number(rawFee);
+
+  if (!Number.isFinite(feeStroops) || feeStroops < 0) {
+    throw new Error("Soroban RPC simulation did not return a valid fee estimate.");
+  }
+
+  return feeStroops;
 }
 
 async function fetchNextOnChainStreamId(
@@ -608,23 +648,8 @@ export async function createStream(input: StreamInput): Promise<StreamRecord> {
     throw new Error("Backend not configured for Soroban.");
   }
 
-  const contract = new Contract(contractId);
-  const endAt = startAt + input.durationSeconds;
-
-  // Let's create an arbitrary testnet asset code for the token
-  const fakeToken = contractId;
-
   const sourceAccount = await rpcServer.getAccount(serverKeypair.publicKey());
-
-  const tx = new Contract(contractId).call(
-    "create_stream",
-    new Address(input.sender).toScVal(),
-    new Address(input.recipient).toScVal(),
-    new Address(fakeToken).toScVal(),
-    nativeToScVal(input.totalAmount, { type: "i128" }),
-    nativeToScVal(startAt, { type: "u64" }),
-    nativeToScVal(endAt, { type: "u64" }),
-  );
+  const tx = createStreamOperation(contractId, input, startAt);
 
   // We have to build and send this tx. Wait, doing this properly via building is long:
   const built = await rpcServer.prepareTransaction(
@@ -698,6 +723,37 @@ export async function createStream(input: StreamInput): Promise<StreamRecord> {
   // must never roll back an already-persisted stream.
   triggerWebhook("created", stream);
   return stream;
+}
+
+export async function estimateCreateStreamFee(input: StreamInput): Promise<StreamFeeEstimate> {
+  const startAt = input.startAt ?? nowInSeconds();
+  const contractId = process.env.CONTRACT_ID;
+  const netPass =
+    process.env.NETWORK_PASSPHRASE || "Test SDF Network ; September 2015";
+
+  if (!contractId || !rpcServer || !serverKeypair) {
+    throw new Error("Backend not configured for Soroban.");
+  }
+
+  const sourceAccount = await rpcServer.getAccount(serverKeypair.publicKey());
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: "1000",
+    networkPassphrase: netPass,
+  })
+    .addOperation(createStreamOperation(contractId, input, startAt))
+    .setTimeout(30)
+    .build();
+
+  const simRes = await rpcServer.simulateTransaction(tx);
+  if (!rpc.Api.isSimulationSuccess(simRes)) {
+    throw new Error("Soroban RPC simulation failed.");
+  }
+
+  const feeStroops = readSimulationFeeStroops(simRes);
+  return {
+    feeStroops,
+    feeXlm: formatStroopsAsXlm(feeStroops),
+  };
 }
 
 

--- a/frontend/src/components/CreateStreamForm.test.tsx
+++ b/frontend/src/components/CreateStreamForm.test.tsx
@@ -1,12 +1,33 @@
 import React from 'react';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { estimateCreateStreamFee, getConfig } from '../services/api';
 import { CreateStreamForm } from '../components/CreateStreamForm';
 
 const VALID_ADDRESS_1 = 'GBX5ZID6H4G365G7O4W6U4E6U4E6U4E6U4E6U4E6U4E6U4E6U4E6U4E6';
 const VALID_ADDRESS_2 = 'GDBX5ZID6H4G365G7O4W6U4E6U4E6U4E6U4E6U4E6U4E6U4E6U4E6U4E';
+
+vi.mock('../services/api', () => ({
+  estimateCreateStreamFee: vi.fn(),
+  getConfig: vi.fn(),
+}));
+
+function fillValidStreamForm(amount = '100', duration = '60') {
+  fireEvent.change(screen.getByLabelText(/Sender Account/i), {
+    target: { value: VALID_ADDRESS_1 },
+  });
+  fireEvent.change(screen.getByLabelText(/Recipient Account/i), {
+    target: { value: VALID_ADDRESS_2 },
+  });
+  fireEvent.change(screen.getByLabelText(/Total Amount/i), {
+    target: { value: amount },
+  });
+  fireEvent.change(screen.getByLabelText(/Duration/i), {
+    target: { value: duration },
+  });
+}
 
 describe('CreateStreamForm Component', () => {
   afterEach(() => {
@@ -16,6 +37,11 @@ describe('CreateStreamForm Component', () => {
   beforeEach(() => {
     window.localStorage.clear();
     vi.clearAllMocks();
+    vi.mocked(getConfig).mockResolvedValue({ allowedAssets: ['USDC', 'XLM'] });
+    vi.mocked(estimateCreateStreamFee).mockResolvedValue({
+      feeStroops: 12345,
+      feeXlm: '0.0012345',
+    });
   });
 
   it('renders all required form fields', () => {
@@ -30,28 +56,32 @@ describe('CreateStreamForm Component', () => {
     expect(screen.getByRole('button', { name: /Create Stream/i })).toBeInTheDocument();
   });
 
-  it('enables submit button and calls onCreate when form is valid', async () => {
-    const user = userEvent.setup();
+  it('previews the simulated fee before confirming a valid stream', async () => {
     const onCreate = vi.fn().mockResolvedValue(undefined);
     render(<CreateStreamForm onCreate={onCreate} walletAddress={VALID_ADDRESS_1} />);
 
-    // Fill out the form
-    await user.clear(screen.getByLabelText(/Sender Account/i));
-    await user.type(screen.getByLabelText(/Sender Account/i), VALID_ADDRESS_1);
-    
-    await user.clear(screen.getByLabelText(/Recipient Account/i));
-    await user.type(screen.getByLabelText(/Recipient Account/i), VALID_ADDRESS_2);
-    
-    await user.clear(screen.getByLabelText(/Total Amount/i));
-    await user.type(screen.getByLabelText(/Total Amount/i), '100');
-    
-    await user.clear(screen.getByLabelText(/Duration/i));
-    await user.type(screen.getByLabelText(/Duration/i), '60');
+    fillValidStreamForm();
 
     const submitButton = screen.getByRole('button', { name: /Create Stream/i });
     expect(submitButton).not.toBeDisabled();
     
-    await user.click(submitButton);
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(estimateCreateStreamFee).toHaveBeenCalledWith(expect.objectContaining({
+        sender: VALID_ADDRESS_1,
+        recipient: VALID_ADDRESS_2,
+        totalAmount: 100,
+        durationSeconds: 3600,
+      }));
+    });
+    expect(onCreate).not.toHaveBeenCalled();
+    expect(await screen.findByText(/Network fee estimate/i)).toBeInTheDocument();
+    expect(screen.getByText('100 USDC')).toBeInTheDocument();
+    expect(screen.getByText('100.000000 USDC/hour')).toBeInTheDocument();
+    expect(screen.getByText('0.0012345 XLM')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Confirm$/i }));
 
     await waitFor(() => {
       expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({
@@ -63,14 +93,23 @@ describe('CreateStreamForm Component', () => {
     });
   });
 
+  it('shows an inline error when fee simulation fails', async () => {
+    vi.mocked(estimateCreateStreamFee).mockRejectedValueOnce(new Error('RPC failed'));
+    render(<CreateStreamForm onCreate={vi.fn()} walletAddress={VALID_ADDRESS_1} />);
+
+    fillValidStreamForm();
+
+    fireEvent.click(screen.getByRole('button', { name: /Create Stream/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('RPC failed');
+  });
+
   it('shows error and disables submit when duration is less than 1 minute (60s)', async () => {
-    const user = userEvent.setup();
     render(<CreateStreamForm onCreate={vi.fn()} walletAddress={VALID_ADDRESS_1} />);
 
     const durationInput = screen.getByLabelText(/Duration/i);
-    await user.clear(durationInput);
-    await user.type(durationInput, '0');
-    await user.tab(); // trigger blur
+    fireEvent.change(durationInput, { target: { value: '0' } });
+    fireEvent.blur(durationInput);
 
     // In CreateStreamForm, submitAttempted must be true or field must be touched for errors to show usually, 
     // but here validateForm is called every render. 
@@ -78,7 +117,7 @@ describe('CreateStreamForm Component', () => {
     // Wait, the requirement says "assert inline error and submit disabled".
     // Let's click submit first to set submitAttempted to true.
     const submitButton = screen.getByRole('button', { name: /Create Stream/i });
-    await user.click(submitButton);
+    fireEvent.click(submitButton);
 
     expect(screen.getByText(/Duration must be at least 1 minute/i)).toBeInTheDocument();
     await waitFor(() => expect(submitButton).toBeDisabled());
@@ -115,7 +154,6 @@ describe('CreateStreamForm Component', () => {
   });
 
   it('shows loading state during submission', async () => {
-    const user = userEvent.setup();
     // Create a promise that we can control
     let resolveSubmit: (value: void | PromiseLike<void>) => void;
     const onCreate = vi.fn().mockImplementation(() => new Promise((resolve) => {
@@ -124,19 +162,16 @@ describe('CreateStreamForm Component', () => {
     
     render(<CreateStreamForm onCreate={onCreate} walletAddress={VALID_ADDRESS_1} />);
 
-    // Fill valid data
-    await user.clear(screen.getByLabelText(/Sender Account/i));
-    await user.type(screen.getByLabelText(/Sender Account/i), VALID_ADDRESS_1);
-    await user.clear(screen.getByLabelText(/Recipient Account/i));
-    await user.type(screen.getByLabelText(/Recipient Account/i), VALID_ADDRESS_2);
+    fillValidStreamForm();
 
-    const submitButton = screen.getByRole('button', { name: /Create Stream/i });
-    await user.click(submitButton);
+    fireEvent.click(screen.getByRole('button', { name: /Create Stream/i }));
+    const confirmButton = await screen.findByRole('button', { name: /^Confirm$/i });
+    fireEvent.click(confirmButton);
 
     await waitFor(() => {
-      expect(submitButton).toBeDisabled();
-      expect(submitButton).toHaveTextContent(/Creating…/i);
-      expect(submitButton).toHaveAttribute('aria-busy', 'true');
+      expect(confirmButton).toBeDisabled();
+      expect(confirmButton).toHaveTextContent(/Creating/i);
+      expect(confirmButton).toHaveAttribute('aria-busy', 'true');
     });
 
     // Finish submission
@@ -145,8 +180,7 @@ describe('CreateStreamForm Component', () => {
     });
 
     await waitFor(() => {
-      expect(submitButton).not.toHaveTextContent(/Creating…/i);
-      expect(submitButton).not.toBeDisabled();
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/CreateStreamForm.tsx
+++ b/frontend/src/components/CreateStreamForm.tsx
@@ -1,5 +1,9 @@
 import { useState, useEffect, FormEvent } from "react";
-import { getConfig } from "../services/api";
+import {
+  estimateCreateStreamFee,
+  getConfig,
+  type StreamFeeEstimate,
+} from "../services/api";
 // Form Draft Autosave [Verified]: Survives refresh, clears on submit/discard, aligns with fields.
 import { useDraftAutosave } from "../hooks/useDraftAutosave";
 import { CreateStreamPayload } from "../types/stream";
@@ -15,6 +19,11 @@ interface CreateStreamFormProps {
   onCreate: (payload: CreateStreamPayload) => Promise<void>;
   apiError?: string | null;
   walletAddress?: string | null;
+}
+
+interface FeePreview {
+  payload: CreateStreamPayload;
+  estimate: StreamFeeEstimate;
 }
 
 function humaniseApiError(raw: string): { title: string; hint: string } {
@@ -109,6 +118,28 @@ const INITIAL_VALUES: FormValues = {
 // Initial fallback if fetch hasn't completed or failed
 const DEFAULT_ALLOWED_ASSETS = ["USDC", "XLM"];
 
+function buildCreateStreamPayload(values: FormValues): CreateStreamPayload {
+  const now = Math.floor(Date.now() / 1000);
+  const offsetMinutes = Number(values.startInMinutes);
+  const startAt =
+    offsetMinutes > 0 ? now + Math.floor(offsetMinutes * 60) : undefined;
+
+  return {
+    sender: values.sender.trim(),
+    recipient: values.recipient.trim(),
+    assetCode: values.assetCode.trim().toUpperCase(),
+    totalAmount: Number(values.totalAmount),
+    durationSeconds: Math.floor(Number(values.durationMinutes) * 60),
+    startAt,
+  };
+}
+
+function formatStreamRate(payload: CreateStreamPayload): string {
+  const durationHours = payload.durationSeconds / 3600;
+  const ratePerHour = durationHours > 0 ? payload.totalAmount / durationHours : 0;
+  return `${ratePerHour.toFixed(6)} ${payload.assetCode}/hour`;
+}
+
 export function CreateStreamForm({
   onCreate,
   apiError,
@@ -151,6 +182,8 @@ export function CreateStreamForm({
   >({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitAttempted, setSubmitAttempted] = useState(false);
+  const [feePreview, setFeePreview] = useState<FeePreview | null>(null);
+  const [simulationError, setSimulationError] = useState<string | null>(null);
 
   const errors: FieldErrors = validateForm(values);
   const formValid = isFormValid(errors);
@@ -168,29 +201,36 @@ export function CreateStreamForm({
   async function handleSubmit(event: FormEvent) {
     event.preventDefault();
     setSubmitAttempted(true);
+    setSimulationError(null);
 
     if (!walletAddress) return;
     if (!formValid) return;
 
     setIsSubmitting(true);
     try {
-      const now = Math.floor(Date.now() / 1000);
-      const offsetMinutes = Number(values.startInMinutes);
-      const startAt =
-        offsetMinutes > 0 ? now + Math.floor(offsetMinutes * 60) : undefined;
+      const payload = buildCreateStreamPayload(values);
+      const estimate = await estimateCreateStreamFee(payload);
+      setFeePreview({ payload, estimate });
+    } catch (err) {
+      setSimulationError(
+        err instanceof Error ? err.message : "Failed to estimate network fee.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
 
-      await onCreate({
-        sender: values.sender.trim(),
-        recipient: values.recipient.trim(),
-        assetCode: values.assetCode.trim().toUpperCase(),
-        totalAmount: Number(values.totalAmount),
-        durationSeconds: Math.floor(Number(values.durationMinutes) * 60),
-        startAt,
-      });
+  async function confirmCreateStream() {
+    if (!feePreview) return;
 
+    setIsSubmitting(true);
+    setSimulationError(null);
+    try {
+      await onCreate(feePreview.payload);
       clearDraft();
       setTouched({});
       setSubmitAttempted(false);
+      setFeePreview(null);
     } finally {
       setIsSubmitting(false);
     }
@@ -232,6 +272,7 @@ export function CreateStreamForm({
   })();
 
   return (
+    <>
     <form onSubmit={handleSubmit} noValidate>
       {hasDraft && (
         <div
@@ -485,15 +526,83 @@ export function CreateStreamForm({
       </div>
 
       <div style={{ display: "flex", gap: "1rem", alignItems: "center", marginTop: "1rem" }}>
+        {simulationError && (
+          <span className="field-error" role="alert">
+            {simulationError}
+          </span>
+        )}
         <button
           className="btn-primary"
           type="submit"
           disabled={isSubmitting || (submitAttempted && !formValid)}
           aria-busy={isSubmitting}
         >
-          {isSubmitting ? "Creating…" : "Create Stream"}
+          {isSubmitting ? "Estimating fee..." : "Create Stream"}
         </button>
       </div>
     </form>
+    {feePreview && (
+      <div className="modal-backdrop" role="presentation">
+        <div
+          className="modal-panel"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="fee-preview-title"
+        >
+          <div className="modal-header">
+            <h3 id="fee-preview-title" className="modal-title">
+              Confirm stream creation
+            </h3>
+            <button
+              type="button"
+              className="modal-close"
+              aria-label="Cancel fee preview"
+              onClick={() => setFeePreview(null)}
+              disabled={isSubmitting}
+            >
+              x
+            </button>
+          </div>
+
+          <dl className="fee-preview-list">
+            <div>
+              <dt>Total amount</dt>
+              <dd>
+                {feePreview.payload.totalAmount} {feePreview.payload.assetCode}
+              </dd>
+            </div>
+            <div>
+              <dt>Stream rate</dt>
+              <dd>{formatStreamRate(feePreview.payload)}</dd>
+            </div>
+            <div>
+              <dt>Network fee estimate</dt>
+              <dd>{feePreview.estimate.feeXlm} XLM</dd>
+            </div>
+          </dl>
+
+          <div className="modal-actions">
+            <button
+              type="button"
+              className="btn-ghost"
+              onClick={() => setFeePreview(null)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={() => void confirmCreateStream()}
+              disabled={isSubmitting}
+              aria-busy={isSubmitting}
+            >
+              {isSubmitting ? "Creating..." : "Confirm"}
+            </button>
+          </div>
+        </div>
+      </div>
+    )}
+    </>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -591,6 +591,35 @@ td {
   justify-content: flex-end;
   margin-top: 0.25rem;
 }
+
+.fee-preview-list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.fee-preview-list div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #f9fafb;
+}
+
+.fee-preview-list dt {
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.fee-preview-list dd {
+  margin: 0;
+  color: #111827;
+  font-weight: 700;
+  text-align: right;
+}
 .chart-section {
   background: white;
   border: 1px solid #e5e7eb;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -169,6 +169,30 @@ export async function createStream(
   return body.data;
 }
 
+export interface StreamFeeEstimate {
+  feeStroops: number;
+  feeXlm: string;
+}
+
+export async function estimateCreateStreamFee(
+  payload: CreateStreamPayload,
+): Promise<StreamFeeEstimate> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (authToken) {
+    headers["Authorization"] = `Bearer ${authToken}`;
+  }
+
+  const response = await fetch(`${API_BASE}/streams/fee-estimate`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  });
+  const body = await parseResponse<{ data: StreamFeeEstimate }>(response);
+  return body.data;
+}
+
 export async function cancelStream(streamId: string): Promise<Stream> {
   const headers: Record<string, string> = {};
   if (authToken) {


### PR DESCRIPTION
Summary
- Adds a create-stream fee preview flow so submitting the form first estimates the Soroban network fee and opens a confirmation modal.
- The preview shows the total amount, stream rate, and network fee estimate in XLM before the user confirms stream creation.
- Simulation errors are shown inline and the existing create flow only runs after Confirm.

Issue
- Closes #460

Changes
- Added a backend `/api/streams/fee-estimate` route that validates the create stream payload and calls Soroban RPC `simulateTransaction` through the existing stream store context.
- Refactored stream transaction construction so creation and fee simulation use the same `create_stream` operation shape.
- Added a frontend API helper for stream fee estimation.
- Updated `CreateStreamForm` to estimate on submit, show a confirmation modal, support Cancel/Confirm, and preserve the form when simulation fails.
- Added Vitest coverage that mocks the fee simulation and asserts the fee preview before confirmation.

Validation
- Ran `npm.cmd --prefix frontend test -- --run src/components/CreateStreamForm.test.tsx` - passed, 1 file / 8 tests.
- Ran `npm.cmd --prefix frontend run build` - failed before this change's code due existing syntax errors in `frontend/src/components/IssueBacklog.tsx`, `IssueBacklog.test.tsx`, `StreamsTable.tsx`, and `StreamsTable.test.tsx`.
- Ran `npm.cmd --prefix backend run build` - failed due existing syntax errors in `backend/src/index.test.ts`, `backend/src/index.ts`, and `backend/src/services/streamStore.ts`.
- Ran `npm.cmd --prefix backend test -- --run src/index.test.ts` - failed because `backend/src/index.test.ts` has a pre-existing parse error at line 416.

Notes
- The original PR opened against `ritik4ever/stellar-bounty-board` was for the wrong repository because the provided issue number belongs to `ritik4ever/stellar-stream`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Stream creation now includes fee estimation before confirmation
  * A confirmation modal displays the estimated network fee, total stream amount, and stream rate details before finalizing creation
  * Submit button displays "Estimating fee..." status while calculating fees

<!-- end of auto-generated comment: release notes by coderabbit.ai -->