### PR TITLE
feat: batch claims, table columns, CSP, and reconciliation interval

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,4 +33,32 @@ Once a report is received through the GitHub Security Advisory form, we commit t
 
 Maintainers: Please ensure that **GitHub Security Advisories** are enabled for this repository to allow researchers to submit reports privately.
 
+## Content Security Policy (CSP)
+
+The frontend build injects a Content Security Policy to limit script execution and network connections, reducing the impact of cross-site scripting (XSS) against wallet connection state.
+
+### Policy
+
+```
+default-src 'self';
+connect-src 'self' https://rpc-futurenet.stellar.org
+```
+
+- **`default-src 'self'`** — Scripts, styles, images, and other subresources load only from the application origin.
+- **`connect-src`** — `fetch`/XHR/WebSocket connections are limited to the app origin (API proxy) and the configured Stellar Futurenet RPC endpoint.
+
+### Rollout
+
+1. **Report-only (default)** — The Vite build sends `Content-Security-Policy-Report-Only` in development, preview, and production builds. Violations are logged by the browser but not blocked.
+2. **Enforcement** — Set `VITE_CSP_ENFORCE=true` when building or serving the frontend to send `Content-Security-Policy` instead. Monitor the browser console for violations before enabling in production.
+
+### Configuration
+
+| Variable | Effect |
+| -------- | ------ |
+| (unset) | Report-only CSP via meta tag and HTTP headers |
+| `VITE_CSP_ENFORCE=true` | Enforcing CSP |
+
+Implementation: `frontend/vite.config.ts` (`content-security-policy` plugin and dev/preview headers).
+
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -30,3 +30,6 @@ JWT_SECRET=your-jwt-secret-here
 
 # Indexer configuration
 INDEXER_POLL_INTERVAL_MS=10000
+
+# Reconciliation job interval in milliseconds (minimum 10000, default 60000 = 1 minute)
+RECONCILIATION_INTERVAL_MS=60000

--- a/backend/src/config/validateEnv.test.ts
+++ b/backend/src/config/validateEnv.test.ts
@@ -404,6 +404,7 @@ describe("validateEnv", () => {
       expect(config).toHaveProperty("serverSigningKey");
       expect(config).toHaveProperty("domain");
       expect(config).toHaveProperty("indexerPollIntervalMs");
+      expect(config).toHaveProperty("reconciliationIntervalMs");
       expect(config).toHaveProperty("adminApiKey");
     });
 
@@ -457,6 +458,43 @@ describe("validateEnv", () => {
       expect(exitSpy).toHaveBeenCalledWith(1);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining("INDEXER_POLL_INTERVAL_MS: must be a valid number >= 5000")
+      );
+    });
+
+    it("should use default RECONCILIATION_INTERVAL_MS of 60000ms", () => {
+      process.env = {
+        SOROBAN_DISABLED: "true",
+      };
+
+      const config = validateEnv();
+
+      expect(config.reconciliationIntervalMs).toBe(60000);
+    });
+
+    it("should accept valid RECONCILIATION_INTERVAL_MS", () => {
+      process.env = {
+        SOROBAN_DISABLED: "true",
+        RECONCILIATION_INTERVAL_MS: "120000",
+      };
+
+      const config = validateEnv();
+
+      expect(config.reconciliationIntervalMs).toBe(120000);
+    });
+
+    it("should enforce minimum RECONCILIATION_INTERVAL_MS of 10000ms", () => {
+      process.env = {
+        SOROBAN_DISABLED: "true",
+        RECONCILIATION_INTERVAL_MS: "5000",
+      };
+
+      try {
+        validateEnv();
+      } catch (e) { }
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("RECONCILIATION_INTERVAL_MS: must be a valid number >= 10000")
       );
     });
   });

--- a/backend/src/config/validateEnv.ts
+++ b/backend/src/config/validateEnv.ts
@@ -38,6 +38,14 @@ const indexerPollIntervalSchema = z
     message: "must be a valid number >= 5000 (minimum 5 seconds)",
   });
 
+// Reconciliation job interval validation
+const reconciliationIntervalSchema = z
+  .string()
+  .transform((val: string) => parseInt(val, 10))
+  .refine((val: number) => !isNaN(val) && val >= 10000, {
+    message: "must be a valid number >= 10000 (minimum 10 seconds)",
+  });
+
 // Admin API key validation
 const adminApiKeySchema = z
   .string()
@@ -62,6 +70,7 @@ const envSchema = z.object({
   DOMAIN: z.string().optional().default("localhost"),
   SOROBAN_DISABLED: z.string().optional(),
   INDEXER_POLL_INTERVAL_MS: indexerPollIntervalSchema.optional().default(10000),
+  RECONCILIATION_INTERVAL_MS: reconciliationIntervalSchema.optional().default(60000),
 });
 
 export interface ValidatedConfig {
@@ -79,6 +88,7 @@ export interface ValidatedConfig {
   serverSigningKey: string | null;
   domain: string;
   indexerPollIntervalMs: number;
+  reconciliationIntervalMs: number;
   adminApiKey: string | null;
 }
 
@@ -225,7 +235,9 @@ export function validateEnv(): ValidatedConfig {
     console.warn("⚠️  ADMIN_API_KEY is not set in production — admin endpoints will be inaccessible");
   }
 
-  console.log(`✅ Configuration validated (port: ${env.PORT}, assets: ${allowedAssets.join(", ")}, indexer interval: ${env.INDEXER_POLL_INTERVAL_MS}ms)`);
+  console.log(
+    `✅ Configuration validated (port: ${env.PORT}, assets: ${allowedAssets.join(", ")}, indexer interval: ${env.INDEXER_POLL_INTERVAL_MS}ms, reconciliation interval: ${env.RECONCILIATION_INTERVAL_MS}ms)`,
+  );
 
   return {
     port: env.PORT,
@@ -242,6 +254,7 @@ export function validateEnv(): ValidatedConfig {
     serverSigningKey: env.SERVER_SIGNING_KEY || null,
     domain: env.DOMAIN,
     indexerPollIntervalMs: env.INDEXER_POLL_INTERVAL_MS,
+    reconciliationIntervalMs: env.RECONCILIATION_INTERVAL_MS,
     adminApiKey,
   };
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -43,6 +43,7 @@ import {
   createStream,
   getStream,
   getOnChainClaimableAmount,
+  getOnChainClaimableBatch,
   getLatestLedgerTime,
   initSoroban,
   listStreams,
@@ -501,6 +502,58 @@ app.get(
   },
 );
 
+const claimableBatchBodySchema = z.object({
+  streamIds: z
+    .array(z.string().regex(/^\d+$/, "Stream ID must be numeric"))
+    .min(1, "At least one stream ID is required")
+    .max(20, "Maximum 20 stream IDs per batch"),
+});
+
+app.post(
+  "/api/streams/claimable/batch",
+  claimableLimiter,
+  async (req: Request, res: Response) => {
+    const parsed = claimableBatchBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendValidationError(req, res, parsed.error.issues);
+      return;
+    }
+
+    for (const streamId of parsed.data.streamIds) {
+      const parsedId = parseStreamId(streamId);
+      if (!parsedId.ok) {
+        sendValidationError(req, res, parsedId.issues);
+        return;
+      }
+      const stream = getStream(parsedId.value);
+      if (!stream) {
+        sendApiError(req, res, 404, `Stream ${streamId} not found.`, {
+          code: "NOT_FOUND",
+        });
+        return;
+      }
+    }
+
+    try {
+      const { amounts, at } = await getOnChainClaimableBatch(parsed.data.streamIds);
+      res.json({ amounts, at });
+    } catch (error: unknown) {
+      console.error("Failed to simulate claimable batch:", error);
+      const normalizedError = normalizeUnknownApiError(
+        error,
+        "Failed to simulate claimable amounts.",
+      );
+      sendApiError(
+        req,
+        res,
+        normalizedError.statusCode,
+        normalizedError.message,
+        { code: normalizedError.code ?? "INTERNAL_ERROR" },
+      );
+    }
+  },
+);
+
 app.get("/api/streams/:id", readLimiter, (req: Request, res: Response) => {
   const parsedId = parseStreamId(req.params.id);
   if (!parsedId.ok) {
@@ -522,7 +575,13 @@ app.get("/api/streams/:id", readLimiter, (req: Request, res: Response) => {
   });
 });
 
-
+app.get(
+  "/api/recipients/:accountId/streams",
+  readLimiter,
+  (req: Request, res: Response) => {
+    const parsedParams = recipientAccountIdSchema.safeParse({
+      accountId: req.params.accountId,
+    });
 
     if (!parsedParams.success) {
       sendValidationError(req, res, parsedParams.error.issues);
@@ -1225,9 +1284,7 @@ async function startServer() {
   if (config.sorobanEnabled && config.contractId) {
     initIndexer(config.rpcUrl, config.contractId, config.networkPassphrase);
     startIndexer(config.indexerPollIntervalMs);
-    startReconciliationJob(
-      Number(process.env.RECONCILIATION_INTERVAL_MS ?? 60000),
-    );
+    startReconciliationJob(config.reconciliationIntervalMs);
   } else {
     console.warn("CONTRACT_ID not set, event indexer will not start");
   }

--- a/backend/src/services/streamStore.ts
+++ b/backend/src/services/streamStore.ts
@@ -9,6 +9,7 @@ import {
   TransactionBuilder,
   Networks,
   Account,
+  xdr,
 } from "@stellar/stellar-sdk";
 import pLimit from "p-limit";
 import { initDb, getDb } from "./db";
@@ -426,6 +427,66 @@ export async function getOnChainClaimableAmount(
 
   const claimableAmount = Number(scValToNative(simRes.result.retval));
   return { claimableAmount, at };
+}
+
+const MAX_CLAIMABLE_BATCH_SIZE = 20;
+
+function parseClaimableBatchMap(native: unknown): Record<string, number> {
+  const result: Record<string, number> = {};
+  if (native instanceof Map) {
+    for (const [key, value] of native.entries()) {
+      result[String(key)] = Number(value);
+    }
+    return result;
+  }
+  if (native && typeof native === "object") {
+    for (const [key, value] of Object.entries(native as Record<string, unknown>)) {
+      result[String(key)] = Number(value);
+    }
+  }
+  return result;
+}
+
+export async function getOnChainClaimableBatch(
+  ids: string[],
+): Promise<{ amounts: Record<string, number>; at: number }> {
+  if (ids.length === 0) {
+    const at = await getLatestLedgerTime();
+    return { amounts: {}, at };
+  }
+  if (ids.length > MAX_CLAIMABLE_BATCH_SIZE) {
+    throw new Error(`Too many stream IDs (max ${MAX_CLAIMABLE_BATCH_SIZE})`);
+  }
+
+  const sorobanContext = getSorobanContext();
+  if (!sorobanContext || !rpcServer) {
+    throw new Error("Soroban RPC server is not initialized.");
+  }
+
+  const sourceAccount = await sorobanContext.sourceAccountPromise;
+  const latestLedger = await rpcServer.getLatestLedger();
+  const at = latestLedger.closeTime
+    ? parseInt(latestLedger.closeTime, 10)
+    : Math.floor(Date.now() / 1000);
+
+  const streamIdVec = xdr.ScVal.scvVec(
+    ids.map((id) => nativeToScVal(parseInt(id, 10), { type: "u64" })),
+  );
+
+  const simRes = await simulateContractCall(
+    sorobanContext.contract,
+    sourceAccount,
+    "get_claimable_batch",
+    streamIdVec,
+    nativeToScVal(at, { type: "u64" }),
+  );
+
+  if (!rpc.Api.isSimulationSuccess(simRes) || !simRes.result) {
+    throw new Error("Simulation failed: " + JSON.stringify(simRes));
+  }
+
+  const amounts = parseClaimableBatchMap(scValToNative(simRes.result.retval));
+  return { amounts, at };
 }
 
 export async function getLatestLedgerTime(): Promise<number> {

--- a/frontend/src/components/ClaimBatchModal.tsx
+++ b/frontend/src/components/ClaimBatchModal.tsx
@@ -1,0 +1,111 @@
+import { useFocusTrap } from "../hooks/useFocusTrap";
+import type { BatchClaimState } from "../hooks/useClaimBatch";
+
+interface ClaimBatchModalProps {
+  state: BatchClaimState;
+  streamCount: number;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export function ClaimBatchModal({
+  state,
+  streamCount,
+  onConfirm,
+  onClose,
+}: ClaimBatchModalProps) {
+  const panelRef = useFocusTrap<HTMLDivElement>(true);
+  const isClaiming = state.phase === "claiming";
+  const isComplete = state.phase === "complete";
+
+  const summaryLabel = `Claim ${state.totalClaimable.toFixed(4)} ${state.assetLabel} across ${streamCount} stream${streamCount !== 1 ? "s" : ""}`;
+
+  return (
+    <div
+      className="modal-backdrop"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !isClaiming) onClose();
+      }}
+    >
+      <div
+        ref={panelRef}
+        className="modal-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="claim-batch-title"
+      >
+        <h2 id="claim-batch-title">Batch claim</h2>
+
+        {state.phase === "fetching" && (
+          <p className="muted" role="status">
+            Loading claimable amounts…
+          </p>
+        )}
+
+        {(state.phase === "ready" || isClaiming || isComplete) && (
+          <>
+            <p>{summaryLabel}</p>
+
+            {isClaiming && (
+              <p className="muted" role="status" aria-live="polite">
+                Claiming {state.progress.current} of {state.progress.total}
+              </p>
+            )}
+
+            {isComplete && (
+              <div role="status" aria-live="polite">
+                <p>
+                  {state.successCount} of {state.progress.total} claim
+                  {state.progress.total !== 1 ? "s" : ""} succeeded.
+                </p>
+                {state.failures.length > 0 && (
+                  <ul className="claim-batch-failures">
+                    {state.failures.map((f) => (
+                      <li key={f.streamId}>
+                        Stream {f.streamId}: {f.message}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            {state.error && (
+              <p className="field-error" role="alert">
+                {state.error}
+              </p>
+            )}
+          </>
+        )}
+
+        <div className="modal-actions">
+          {state.phase === "ready" && (
+            <>
+              <button type="button" className="btn-ghost" onClick={onClose}>
+                Cancel
+              </button>
+              <button type="button" className="btn-primary" onClick={onConfirm}>
+                Confirm claim
+              </button>
+            </>
+          )}
+          {isClaiming && (
+            <button type="button" className="btn-primary" disabled aria-busy="true">
+              Claiming…
+            </button>
+          )}
+          {isComplete && (
+            <button type="button" className="btn-primary" onClick={onClose}>
+              Close
+            </button>
+          )}
+          {state.phase === "fetching" && (
+            <button type="button" className="btn-ghost" onClick={onClose}>
+              Cancel
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/RecipientDashboard.tsx
+++ b/frontend/src/components/RecipientDashboard.tsx
@@ -3,6 +3,8 @@ import { listRecipientStreams, StreamEvent } from "../services/api";
 import { Stream } from "../types/stream";
 import { CopyableAddress } from "./CopyableAddress";
 import { useClaimStream, ClaimState } from "../hooks/useClaimStream";
+import { useClaimBatch, type BatchClaimInput } from "../hooks/useClaimBatch";
+import { ClaimBatchModal } from "./ClaimBatchModal";
 import { ClaimResult } from "../services/soroban";
 
 interface RecipientDashboardProps {
@@ -113,6 +115,8 @@ export function RecipientDashboard({ recipientAddress }: RecipientDashboardProps
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
+  const [batchModalOpen, setBatchModalOpen] = useState(false);
+  const [pendingBatchInputs, setPendingBatchInputs] = useState<BatchClaimInput[]>([]);
 
   // Auto-dismiss toast after 5 s
   useEffect(() => {
@@ -148,6 +152,25 @@ export function RecipientDashboard({ recipientAddress }: RecipientDashboardProps
     },
     [refreshStreams],
   );
+
+  const handleBatchClaimSuccess = useCallback(
+    async (streamId: string, result: ClaimResult, _history: StreamEvent[]) => {
+      await refreshStreams();
+      setToast({
+        message: `Successfully claimed ${result.claimedAmount} from stream ${streamId}.`,
+        type: "success",
+      });
+    },
+    [refreshStreams],
+  );
+
+  const {
+    state: batchState,
+    fetchClaimable,
+    executeBatch,
+    reset: resetBatch,
+    isClaiming: isBatchClaiming,
+  } = useClaimBatch(handleBatchClaimSuccess);
 
   const handleClaimFailure = useCallback((_streamId: string, message: string) => {
     setToast({ message, type: "error" });
@@ -277,6 +300,28 @@ export function RecipientDashboard({ recipientAddress }: RecipientDashboardProps
         />
       )}
 
+      {batchModalOpen && (
+        <ClaimBatchModal
+          state={batchState}
+          streamCount={pendingBatchInputs.length}
+          onConfirm={async () => {
+            if (!recipientAddress) return;
+            const claimable = pendingBatchInputs
+              .map((input) => ({
+                ...input,
+                amount: batchState.claimableByStreamId[input.streamId] ?? 0,
+              }))
+              .filter((input) => input.amount > 0);
+            await executeBatch(claimable, recipientAddress);
+          }}
+          onClose={() => {
+            setBatchModalOpen(false);
+            resetBatch();
+            setPendingBatchInputs([]);
+          }}
+        />
+      )}
+
       <div className="card recipient-dashboard-card">
         <h2 className="recipient-dashboard-title">Recipient Dashboard</h2>
         <p className="muted recipient-dashboard-subtitle">
@@ -304,7 +349,48 @@ export function RecipientDashboard({ recipientAddress }: RecipientDashboardProps
 
         {activeStreams.length > 0 && (
           <section className="recipient-dashboard-section">
-            <h3 className="recipient-dashboard-section-title">Active streams</h3>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                marginBottom: "0.75rem",
+              }}
+            >
+              <h3 className="recipient-dashboard-section-title" style={{ margin: 0 }}>
+                Active streams
+              </h3>
+              {activeStreams.length > 1 && recipientAddress && (
+                <button
+                  type="button"
+                  className="btn-claim"
+                  disabled={isPending || isBatchClaiming}
+                  onClick={async () => {
+                    const inputs: BatchClaimInput[] = activeStreams.map((s) => ({
+                      streamId: s.id,
+                      amount: s.progress.vestedAmount,
+                      assetCode: s.assetCode,
+                    }));
+                    setPendingBatchInputs(inputs);
+                    setBatchModalOpen(true);
+                    try {
+                      await fetchClaimable(inputs);
+                    } catch (err) {
+                      setBatchModalOpen(false);
+                      setToast({
+                        message:
+                          err instanceof Error
+                            ? err.message
+                            : "Failed to load claimable amounts.",
+                        type: "error",
+                      });
+                    }
+                  }}
+                >
+                  Claim all
+                </button>
+              )}
+            </div>
             <div className="table-wrap">
               <table>
                 <thead>
@@ -414,10 +500,12 @@ export function RecipientDashboard({ recipientAddress }: RecipientDashboardProps
         )}
 
         {/* Global pending indicator — shown when any claim is in-flight */}
-        {isPending && (
+        {(isPending || isBatchClaiming) && (
           <div className="claim-pending-banner" role="status" aria-live="polite">
             <span className="btn-claim__spinner" aria-hidden="true" />
-            Waiting for on-chain confirmation…
+            {isBatchClaiming && batchState.progress.total > 0
+              ? `Claiming ${batchState.progress.current} of ${batchState.progress.total}…`
+              : "Waiting for on-chain confirmation…"}
           </div>
         )}
       </div>

--- a/frontend/src/components/StreamsTable.test.tsx
+++ b/frontend/src/components/StreamsTable.test.tsx
@@ -1,19 +1,76 @@
-import React from 'react';
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { StreamsTable } from "./StreamsTable";
+import { Stream } from "../types/stream";
 
-import { StreamsTable } from './StreamsTable';
-import { Stream } from '../types/stream';
-import * as api from '../services/api';
+const noop = vi.fn().mockResolvedValue(undefined);
 
-
+const mockStreams: Stream[] = [
+  {
+    id: "1",
+    sender: "G_SENDER123456789012345678901234567890123456789012345678901",
+    recipient: "G_RECIPIENT123456789012345678901234567890123456789012345",
+    assetCode: "USDC",
+    totalAmount: 100,
+    durationSeconds: 3600,
+    startAt: 1670000000,
+    createdAt: 1670000000,
+    progress: {
+      status: "active",
+      ratePerSecond: 0.01,
+      elapsedSeconds: 100,
+      vestedAmount: 20,
+      remainingAmount: 80,
+      percentComplete: 20,
+    },
   },
-});
+];
 
+const defaultProps = {
+  streams: mockStreams,
+  filters: {},
+  onFiltersChange: vi.fn(),
+  onCancel: noop,
+  onPause: noop,
+  onResume: noop,
+  onEditStartTime: vi.fn(),
+};
+
+describe("StreamsTable column visibility", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
 
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
   });
 
+  it("hides optional column by default and shows it when toggled", () => {
+    render(<StreamsTable {...defaultProps} />);
 
+    expect(screen.queryByRole("columnheader", { name: "Asset" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle table columns" }));
+    fireEvent.click(screen.getByLabelText("Asset"));
+
+    expect(screen.getByRole("columnheader", { name: "Asset" })).toBeInTheDocument();
+    expect(screen.getByText("USDC")).toBeInTheDocument();
+  });
+
+  it("persists column visibility to localStorage", () => {
+    const { unmount } = render(<StreamsTable {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle table columns" }));
+    fireEvent.click(screen.getByLabelText("Asset"));
+
+    const stored = JSON.parse(localStorage.getItem("stream-table-columns") ?? "{}");
+    expect(stored.assetCode).toBe(true);
+
+    unmount();
+    render(<StreamsTable {...defaultProps} />);
+
+    expect(screen.getByRole("columnheader", { name: "Asset" })).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/StreamsTable.tsx
+++ b/frontend/src/components/StreamsTable.tsx
@@ -1,10 +1,24 @@
-
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
 import { Stream } from "../types/stream";
 import { getExportCsvUrl, ListStreamsFilters, cancelStream } from "../services/api";
 import { CopyableAddress } from "./CopyableAddress";
 import { StreamTimeline } from "./StreamTimeline";
 import { getHealthBadges } from "../utils/streamHealthBadges";
 import { FilterBar } from "./FilterBar";
+import {
+  OPTIONAL_COLUMN_LABELS,
+  OPTIONAL_STREAM_COLUMNS,
+  useStreamTableColumns,
+  type OptionalStreamColumn,
+} from "../hooks/useStreamTableColumns";
 
 interface StreamsTableProps {
   streams: Stream[];
@@ -15,39 +29,37 @@ interface StreamsTableProps {
   onPause: (streamId: string) => Promise<void>;
   onResume: (streamId: string) => Promise<void>;
   onOpenStream?: (streamId: string) => void;
-  /**
-   * Called when the user clicks "Edit" for a scheduled stream.
-   * Receives the stream AND the button ref so the modal can return focus.
-   */
   onEditStartTime: (stream: Stream, triggerRef: RefObject<HTMLButtonElement | null>) => void;
-  onRefresh?: () => void;
 }
-
-// ── Skeleton rows (#397) ──────────────────────────────────────────────────
 
 const SKELETON_ROW_COUNT = 6;
 
-function SkeletonRow() {
+function SkeletonRow({ colCount }: { colCount: number }) {
   return (
     <tr aria-hidden="true">
-      <td><div className="skeleton" style={{ width: "80px", height: "16px" }} /></td>
-      <td><div className="skeleton" style={{ width: "120px", height: "32px" }} /></td>
-      <td><div className="skeleton" style={{ width: "90px", height: "16px" }} /></td>
-      <td><div className="skeleton" style={{ width: "100%", height: "20px" }} /></td>
-      <td><div className="skeleton" style={{ width: "70px", height: "20px" }} /></td>
-      <td><div className="skeleton" style={{ width: "80px", height: "28px" }} /></td>
+      {Array.from({ length: colCount }, (_, i) => (
+        <td key={i}>
+          <div className="skeleton" style={{ width: "80px", height: "16px" }} />
+        </td>
+      ))}
     </tr>
   );
 }
 
 function statusClass(status: Stream["progress"]["status"]): string {
   switch (status) {
-    case "active":    return "badge badge-active";
-    case "scheduled": return "badge badge-scheduled";
-    case "completed": return "badge badge-completed";
-    case "canceled":  return "badge badge-canceled";
-    case "paused":    return "badge badge-paused";
-    default:          return "badge";
+    case "active":
+      return "badge badge-active";
+    case "scheduled":
+      return "badge badge-scheduled";
+    case "completed":
+      return "badge badge-completed";
+    case "canceled":
+      return "badge badge-canceled";
+    case "paused":
+      return "badge badge-paused";
+    default:
+      return "badge";
   }
 }
 
@@ -55,120 +67,77 @@ function formatTimestamp(unixSeconds: number): string {
   return new Date(unixSeconds * 1000).toLocaleString();
 }
 
-type SortColumn = "status" | "amount" | "vested" | "startDate" | null;
-type SortDirection = "asc" | "desc" | null;
+function formatDuration(seconds: number): string {
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  if (seconds < 86400) return `${(seconds / 3600).toFixed(1)}h`;
+  return `${(seconds / 86400).toFixed(1)}d`;
+}
 
 export function StreamsTable({
   streams,
+  loading = false,
   filters,
   onFiltersChange,
   onCancel,
   onPause,
   onResume,
-  onOpenStream,
   onEditStartTime,
-  onRefresh,
+  onOpenStream,
 }: StreamsTableProps) {
-  const [expandedStreamId, setExpandedStreamId] = useState<string | null>(null);
-  const [sortColumn, setSortColumn] = useState<SortColumn>(null);
-  const [sortDirection, setSortDirection] = useState<SortDirection>(null);
+  const { visibility, toggleColumn, isVisible } = useStreamTableColumns();
+  const [columnsOpen, setColumnsOpen] = useState(false);
+  const columnsRef = useRef<HTMLDivElement>(null);
+
   const [selectedStreamIds, setSelectedStreamIds] = useState<Set<string>>(new Set());
-  const [isBulkCanceling, setIsBulkCanceling] = useState<boolean>(false);
-  const [bulkCancelProgress, setBulkCancelProgress] = useState<{ current: number; total: number }>({
-    current: 0,
-    total: 0,
-  });
+  const [expandedStreamId, setExpandedStreamId] = useState<string | null>(null);
+  const [isBulkCanceling, setIsBulkCanceling] = useState(false);
+  const [bulkCancelProgress, setBulkCancelProgress] = useState({ current: 0, total: 0 });
 
-  const exportUrl = useMemo(() => getExportCsvUrl(filters as Record<string, string>), [filters]);
+  const exportUrl = useMemo(() => getExportCsvUrl(filters), [filters]);
 
-  const toggleTimeline = (streamId: string) => {
-    setExpandedStreamId((prev) => (prev === streamId ? null : streamId));
-  };
+  const sortedStreams = useMemo(
+    () => [...streams].sort((a, b) => a.id.localeCompare(b.id)),
+    [streams],
+  );
 
+  const visibleOptionalColumns = useMemo(
+    () => OPTIONAL_STREAM_COLUMNS.filter((col) => isVisible(col)),
+    [isVisible, visibility],
+  );
 
-  // Sort streams based on current sort state
-  const sortedStreams = useMemo(() => {
-    if (!sortColumn || !sortDirection) {
-      return streams;
-    }
+  const colCount = 7 + visibleOptionalColumns.length;
 
-    const sorted = [...streams];
+  const isStreamSelectable = useCallback((stream: Stream): boolean => {
+    return (
+      stream.progress.status === "active" || stream.progress.status === "scheduled"
+    );
+  }, []);
 
-    sorted.sort((a, b) => {
-      let valueA: number | string | Date;
-      let valueB: number | string | Date;
+  const selectableStreams = useMemo(
+    () => streams.filter(isStreamSelectable),
+    [streams, isStreamSelectable],
+  );
+  const selectableIds = useMemo(
+    () => new Set(selectableStreams.map((s) => s.id)),
+    [selectableStreams],
+  );
 
-      switch (sortColumn) {
-        case "status": {
-          const statusOrder: Record<string, number> = {
-            active: 0,
-            scheduled: 1,
-            completed: 2,
-            canceled: 3,
-            paused: 4,
-          };
-          valueA = statusOrder[a.progress.status] ?? 999;
-          valueB = statusOrder[b.progress.status] ?? 999;
-          break;
-        }
-        case "amount": {
-          valueA = a.totalAmount;
-          valueB = b.totalAmount;
-          break;
-        }
-        case "vested": {
-          valueA = a.progress.vestedAmount;
-          valueB = b.progress.vestedAmount;
-          break;
-        }
-        case "startDate": {
-          valueA = a.startAt;
-          valueB = b.startAt;
-          break;
-        }
-        default:
-          return 0;
-      }
+  const allSelectableSelected = useMemo(
+    () =>
+      selectableStreams.length > 0 &&
+      selectableStreams.every((stream) => selectedStreamIds.has(stream.id)),
+    [selectableStreams, selectedStreamIds],
+  );
 
-      if (valueA < valueB) {
-        return sortDirection === "asc" ? -1 : 1;
-      }
-      if (valueA > valueB) {
-        return sortDirection === "asc" ? 1 : -1;
-      }
-      return 0;
-    });
-
-    return sorted;
-  }, [streams, sortColumn, sortDirection]);
-
-  // Helper: determine if a stream is eligible for selection (active or scheduled)
-
-
-  // Get all selectable streams on current page
-  const selectableStreams = useMemo(() => streams.filter(isStreamSelectable), [streams, isStreamSelectable]);
-  const selectableIds = useMemo(() => new Set(selectableStreams.map((s) => s.id)), [selectableStreams]);
-
-  // Determine if all selectable streams are selected
-  const allSelectableSelected = useMemo(() =>
-    selectableStreams.length > 0 &&
-    selectableStreams.every((stream) => selectedStreamIds.has(stream.id)),
-  [selectableStreams, selectedStreamIds]);
-
-  // Handle individual checkbox toggle
   const handleCheckboxToggle = useCallback((streamId: string) => {
     setSelectedStreamIds((prev) => {
       const next = new Set(prev);
-      if (next.has(streamId)) {
-        next.delete(streamId);
-      } else {
-        next.add(streamId);
-      }
+      if (next.has(streamId)) next.delete(streamId);
+      else next.add(streamId);
       return next;
     });
   }, []);
 
-  // Handle "Select All" toggle
   const handleSelectAllToggle = useCallback(() => {
     if (allSelectableSelected) {
       setSelectedStreamIds((prev) => {
@@ -189,7 +158,6 @@ export function StreamsTable({
     setExpandedStreamId((prev) => (prev === id ? null : id));
   }, []);
 
-  // Sequential bulk cancellation
   const handleBulkCancel = useCallback(async () => {
     const idsToCancel = Array.from(selectedStreamIds);
     if (idsToCancel.length === 0) return;
@@ -197,28 +165,20 @@ export function StreamsTable({
     setIsBulkCanceling(true);
     setBulkCancelProgress({ current: 0, total: idsToCancel.length });
 
-    let successCount = 0;
-    let failureCount = 0;
-
     for (let i = 0; i < idsToCancel.length; i++) {
-      const streamId = idsToCancel[i];
       setBulkCancelProgress({ current: i + 1, total: idsToCancel.length });
       try {
-        await cancelStream(streamId);
-        successCount++;
+        await cancelStream(idsToCancel[i]);
       } catch (error) {
-        console.error(`Failed to cancel stream ${streamId}:`, error);
-        failureCount++;
+        console.error(`Failed to cancel stream ${idsToCancel[i]}:`, error);
       }
     }
 
     setSelectedStreamIds(new Set());
     setIsBulkCanceling(false);
     setBulkCancelProgress({ current: 0, total: 0 });
-    console.log(`Bulk cancellation complete: ${successCount} succeeded, ${failureCount} failed`);
   }, [selectedStreamIds]);
 
-  // Clear selections when streams change (e.g., after filter change)
   useEffect(() => {
     setSelectedStreamIds((prev) => {
       const validIds = new Set(streams.map((s) => s.id));
@@ -230,13 +190,114 @@ export function StreamsTable({
     });
   }, [streams]);
 
-  return (
+  useEffect(() => {
+    if (!columnsOpen) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (columnsRef.current && !columnsRef.current.contains(e.target as Node)) {
+        setColumnsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [columnsOpen]);
 
+  return (
+    <>
+      <div className="card">
+        <FilterBar filters={filters} onChange={onFiltersChange} />
+        <div
+          className="streams-table-toolbar"
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: "1rem",
+            gap: "0.75rem",
+          }}
+        >
+          <h2 style={{ margin: 0 }}>Live Streams</h2>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+            <div className="column-toggle" ref={columnsRef} style={{ position: "relative" }}>
+              <button
+                type="button"
+                className="btn-ghost"
+                aria-expanded={columnsOpen}
+                aria-haspopup="true"
+                aria-label="Toggle table columns"
+                onClick={() => setColumnsOpen((o) => !o)}
+              >
+                ⊞ Columns
+              </button>
+              {columnsOpen && (
+                <div
+                  className="column-toggle-popover"
+                  role="dialog"
+                  aria-label="Column visibility"
+                  style={{
+                    position: "absolute",
+                    right: 0,
+                    top: "100%",
+                    marginTop: "0.25rem",
+                    zIndex: 20,
+                    background: "var(--color-background)",
+                    border: "1px solid var(--color-border)",
+                    borderRadius: "8px",
+                    padding: "0.75rem",
+                    minWidth: "200px",
+                    boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+                  }}
+                >
+                  <p className="muted" style={{ margin: "0 0 0.5rem", fontSize: "0.85rem" }}>
+                    Optional columns
+                  </p>
+                  {OPTIONAL_STREAM_COLUMNS.map((col) => (
+                    <label
+                      key={col}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "0.5rem",
+                        marginBottom: "0.35rem",
+                        cursor: "pointer",
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={isVisible(col)}
+                        onChange={() => toggleColumn(col)}
+                      />
+                      {OPTIONAL_COLUMN_LABELS[col]}
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+            <a href={exportUrl} className="btn-ghost" download>
+              Export CSV
+            </a>
+          </div>
+        </div>
+
+        <div style={{ overflowX: "auto" }}>
+          <table aria-busy={loading} aria-label="Streams">
+            <thead>
+              <tr>
+                <th>
+                  <input
+                    type="checkbox"
+                    aria-label="Select all streams"
+                    checked={allSelectableSelected}
+                    onChange={handleSelectAllToggle}
+                    disabled={loading}
                   />
                 </th>
                 <th>ID</th>
-                <th>Addresses</th>
-                <th>Amount</th>
+                <th>Sender</th>
+                <th>Recipient</th>
+                {isVisible("assetCode") && <th>Asset</th>}
+                {isVisible("duration") && <th>Duration</th>}
+                {isVisible("ratePerSecond") && <th>Rate / sec</th>}
+                {isVisible("pausedDuration") && <th>Paused</th>}
                 <th>Progress</th>
                 <th>Status</th>
                 <th>Actions</th>
@@ -245,38 +306,35 @@ export function StreamsTable({
             <tbody>
               {loading
                 ? Array.from({ length: SKELETON_ROW_COUNT }, (_, i) => (
-                    <SkeletonRow key={i} />
+                    <SkeletonRow key={i} colCount={colCount} />
                   ))
-                : sortedStreams.map((stream) => {
-                    const isScheduled = stream.progress.status === "scheduled";
-                    const isFinalised =
-                      stream.progress.status === "completed" ||
-                      stream.progress.status === "canceled";
-                    const isExpanded = expandedStreamId === stream.id;
-                    const healthBadges = getHealthBadges(stream);
-                    return (
-                      <StreamRow
-                        key={stream.id}
-                        stream={stream}
-                        isScheduled={isScheduled}
-                        isFinalised={isFinalised}
-                        isExpanded={isExpanded}
-                        healthBadges={healthBadges}
-                        isSelected={selectedStreamIds.has(stream.id)}
-                        onToggleTimeline={toggleTimeline}
-                        onCheckboxToggle={handleCheckboxToggle}
-                        onCancel={onCancel}
-                        onPause={onPause}
-                        onResume={onResume}
-                        onEditStartTime={onEditStartTime}
-                        onOpenStream={onOpenStream}
-                      />
-                    );
-                  })}
+                : sortedStreams.map((stream) => (
+                    <StreamRow
+                      key={stream.id}
+                      stream={stream}
+                      isScheduled={stream.progress.status === "scheduled"}
+                      isFinalised={
+                        stream.progress.status === "completed" ||
+                        stream.progress.status === "canceled"
+                      }
+                      isExpanded={expandedStreamId === stream.id}
+                      healthBadges={getHealthBadges(stream)}
+                      isSelected={selectedStreamIds.has(stream.id)}
+                      visibleOptionalColumns={visibleOptionalColumns}
+                      colSpan={colCount}
+                      onToggleTimeline={toggleTimeline}
+                      onCheckboxToggle={handleCheckboxToggle}
+                      onCancel={onCancel}
+                      onPause={onPause}
+                      onResume={onResume}
+                      onEditStartTime={onEditStartTime}
+                      onOpenStream={onOpenStream}
+                    />
+                  ))}
             </tbody>
           </table>
         </div>
-
+      </div>
 
       {selectedStreamIds.size > 0 && (
         <BulkActionBar
@@ -286,7 +344,7 @@ export function StreamsTable({
           progress={bulkCancelProgress}
         />
       )}
-    </div>
+    </>
   );
 }
 
@@ -330,9 +388,8 @@ interface StreamRowProps {
   isExpanded: boolean;
   isSelected: boolean;
   healthBadges: ReturnType<typeof getHealthBadges>;
-  isSelected: boolean;
-  isSelectable: boolean;
-  onToggleSelect: () => void;
+  visibleOptionalColumns: OptionalStreamColumn[];
+  colSpan: number;
   onToggleTimeline: (id: string) => void;
   onCheckboxToggle: (id: string) => void;
   onCancel: (id: string) => Promise<void>;
@@ -349,9 +406,8 @@ const StreamRow = memo(function StreamRow({
   isExpanded,
   isSelected,
   healthBadges,
-  isSelected,
-  isSelectable,
-  onToggleSelect,
+  visibleOptionalColumns,
+  colSpan,
   onToggleTimeline,
   onCheckboxToggle,
   onCancel,
@@ -363,55 +419,11 @@ const StreamRow = memo(function StreamRow({
   const editBtnRef = useRef<HTMLButtonElement>(null);
   const isPaused = stream.progress.status === "paused";
   const isActive = stream.progress.status === "active";
+  const show = (col: OptionalStreamColumn) => visibleOptionalColumns.includes(col);
 
   return (
     <>
-      <tr
-        tabIndex={0}
-        className="stream-table-row-focusable"
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            const target = e.target as HTMLElement;
-            if (
-              target.tagName === "BUTTON" ||
-              target.closest("button") ||
-              target.tagName === "A" ||
-              target.closest("a") ||
-              target.tagName === "INPUT" ||
-              target.closest("input")
-            ) {
-              return;
-            }
-            e.preventDefault();
-            onOpenStream?.(stream.id);
-          }
-        }}
-        onClick={(e) => {
-          const target = e.target as HTMLElement;
-          if (
-            target.tagName === "BUTTON" ||
-            target.closest("button") ||
-            target.tagName === "A" ||
-            target.closest("a") ||
-            target.tagName === "INPUT" ||
-            target.closest("input")
-          ) {
-            return;
-          }
-          onOpenStream?.(stream.id);
-        }}
-      >
-        <td style={{ width: "40px", textAlign: "center" }}>
-          {isSelectable && (
-            <input
-              type="checkbox"
-              checked={isSelected}
-              onChange={onToggleSelect}
-              aria-label={`Select stream ${stream.id}`}
-              style={{ cursor: "pointer" }}
-            />
-          )}
-        </td>
+      <tr>
         <td>
           <input
             type="checkbox"
@@ -437,15 +449,19 @@ const StreamRow = memo(function StreamRow({
           </button>
         </td>
         <td>
-          <div className="stacked">
-            <CopyableAddress address={stream.sender} truncationMode="end" />
-            <CopyableAddress address={stream.recipient} truncationMode="end" />
-          </div>
+          <CopyableAddress address={stream.sender} truncationMode="end" />
         </td>
         <td>
-          {stream.totalAmount} {stream.assetCode}
-          <div className="muted">Start: {formatTimestamp(stream.startAt)}</div>
+          <CopyableAddress address={stream.recipient} truncationMode="end" />
         </td>
+        {show("assetCode") && <td>{stream.assetCode}</td>}
+        {show("duration") && <td>{formatDuration(stream.durationSeconds)}</td>}
+        {show("ratePerSecond") && (
+          <td>{stream.progress.ratePerSecond.toFixed(6)}</td>
+        )}
+        {show("pausedDuration") && (
+          <td>{stream.pausedDuration ?? 0}s</td>
+        )}
         <td>
           <div className="progress-copy">
             <strong>{stream.progress.percentComplete}%</strong>
@@ -531,7 +547,7 @@ const StreamRow = memo(function StreamRow({
       {isExpanded && (
         <tr id={`timeline-${stream.id}`}>
           <td
-            colSpan={7}
+            colSpan={colSpan}
             style={{
               padding: "1rem 1.5rem",
               background: "var(--color-background-secondary)",
@@ -548,5 +564,6 @@ const StreamRow = memo(function StreamRow({
   prev.isExpanded === next.isExpanded &&
   prev.isSelected === next.isSelected &&
   prev.isScheduled === next.isScheduled &&
-  prev.isFinalised === next.isFinalised
+  prev.isFinalised === next.isFinalised &&
+  prev.visibleOptionalColumns.join() === next.visibleOptionalColumns.join()
 );

--- a/frontend/src/hooks/useClaimBatch.ts
+++ b/frontend/src/hooks/useClaimBatch.ts
@@ -1,0 +1,166 @@
+import { useCallback, useRef, useState } from "react";
+import { claimStream, getClaimableBatch, ClaimResult } from "../services/soroban";
+import type { StreamEvent } from "../services/api";
+
+export type BatchClaimPhase = "idle" | "fetching" | "ready" | "claiming" | "complete";
+
+export interface BatchClaimFailure {
+  streamId: string;
+  message: string;
+}
+
+export interface BatchClaimState {
+  phase: BatchClaimPhase;
+  claimableByStreamId: Record<string, number>;
+  totalClaimable: number;
+  assetLabel: string;
+  progress: { current: number; total: number };
+  failures: BatchClaimFailure[];
+  successCount: number;
+  error: string | null;
+}
+
+export interface BatchClaimInput {
+  streamId: string;
+  amount: number;
+  assetCode: string;
+}
+
+const initialState: BatchClaimState = {
+  phase: "idle",
+  claimableByStreamId: {},
+  totalClaimable: 0,
+  assetLabel: "XLM",
+  progress: { current: 0, total: 0 },
+  failures: [],
+  successCount: 0,
+  error: null,
+};
+
+/**
+ * Batch claim hook: fetches claimable amounts via get_claimable_batch simulation,
+ * then signs and submits each claim transaction sequentially.
+ */
+export function useClaimBatch(
+  onSuccess: (streamId: string, result: ClaimResult, history: StreamEvent[]) => void,
+) {
+  const [state, setState] = useState<BatchClaimState>(initialState);
+  const runIdRef = useRef(0);
+
+  const reset = useCallback(() => {
+    runIdRef.current += 1;
+    setState(initialState);
+  }, []);
+
+  const fetchClaimable = useCallback(
+    async (inputs: BatchClaimInput[]): Promise<BatchClaimInput[]> => {
+      const streamIds = inputs.map((i) => i.streamId);
+      if (streamIds.length === 0) {
+        return [];
+      }
+
+      const runId = ++runIdRef.current;
+      setState((s) => ({ ...s, phase: "fetching", error: null }));
+
+      try {
+        const { amounts } = await getClaimableBatch(streamIds);
+        if (runIdRef.current !== runId) return [];
+
+        const claimable = inputs
+          .map((input) => ({
+            ...input,
+            amount: amounts[input.streamId] ?? 0,
+          }))
+          .filter((input) => input.amount > 0);
+
+        const totalClaimable = claimable.reduce((sum, i) => sum + i.amount, 0);
+        const assetCodes = new Set(claimable.map((i) => i.assetCode));
+        const assetLabel =
+          assetCodes.size === 1 ? [...assetCodes][0] : "tokens";
+
+        setState({
+          phase: "ready",
+          claimableByStreamId: Object.fromEntries(
+            claimable.map((i) => [i.streamId, i.amount]),
+          ),
+          totalClaimable,
+          assetLabel,
+          progress: { current: 0, total: claimable.length },
+          failures: [],
+          successCount: 0,
+          error: null,
+        });
+
+        return claimable;
+      } catch (err) {
+        if (runIdRef.current !== runId) return [];
+        const message =
+          err instanceof Error ? err.message : "Failed to fetch claimable amounts.";
+        setState((s) => ({ ...s, phase: "idle", error: message }));
+        throw err;
+      }
+    },
+    [],
+  );
+
+  const executeBatch = useCallback(
+    async (claimable: BatchClaimInput[], recipientAddress: string) => {
+      if (claimable.length === 0) return;
+
+      const runId = ++runIdRef.current;
+      const failures: BatchClaimFailure[] = [];
+      let successCount = 0;
+
+      setState((s) => ({
+        ...s,
+        phase: "claiming",
+        progress: { current: 0, total: claimable.length },
+        failures: [],
+        successCount: 0,
+      }));
+
+      for (let i = 0; i < claimable.length; i++) {
+        if (runIdRef.current !== runId) return;
+
+        const { streamId, amount } = claimable[i];
+        setState((s) => ({
+          ...s,
+          progress: { current: i + 1, total: claimable.length },
+        }));
+
+        try {
+          const { result, history } = await claimStream(
+            streamId,
+            recipientAddress,
+            amount,
+          );
+          successCount++;
+          await onSuccess(streamId, result, history);
+        } catch (err) {
+          const message =
+            err instanceof Error ? err.message : "Claim failed. Please try again.";
+          failures.push({ streamId, message });
+        }
+      }
+
+      if (runIdRef.current !== runId) return;
+
+      setState((s) => ({
+        ...s,
+        phase: "complete",
+        failures,
+        successCount,
+        progress: { current: claimable.length, total: claimable.length },
+      }));
+    },
+    [onSuccess],
+  );
+
+  return {
+    state,
+    fetchClaimable,
+    executeBatch,
+    reset,
+    isClaiming: state.phase === "claiming",
+  };
+}

--- a/frontend/src/hooks/useClaimStream.test.ts
+++ b/frontend/src/hooks/useClaimStream.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { useClaimStream } from "./useClaimStream";
-import { claimStream, SorobanClaimError, ClaimResult } from "../services/soroban";
+import { useClaimBatch } from "./useClaimBatch";
+import {
+  claimStream,
+  getClaimableBatch,
+  SorobanClaimError,
+  ClaimResult,
+} from "../services/soroban";
 import type { StreamEvent } from "../services/api";
 
 // Mock the soroban module
 vi.mock("../services/soroban", () => ({
   claimStream: vi.fn(),
+  getClaimableBatch: vi.fn(),
   SorobanClaimError: class SorobanClaimError extends Error {
     code: string;
     constructor(message: string, code: string) {
@@ -18,6 +25,7 @@ vi.mock("../services/soroban", () => ({
 }));
 
 const mockClaimStream = vi.mocked(claimStream);
+const mockGetClaimableBatch = vi.mocked(getClaimableBatch);
 
 describe("useClaimStream", () => {
   beforeEach(() => {
@@ -372,6 +380,80 @@ describe("useClaimStream", () => {
       expect.objectContaining({ claimedAmount: 250.5 }), 
       mockHistory
     );
+  });
+
+  describe("useClaimBatch", () => {
+    it("fetches claimable batch and claims streams sequentially", async () => {
+      mockGetClaimableBatch.mockResolvedValue({
+        amounts: { "1": 100, "2": 50 },
+        at: 1716812160,
+      });
+
+      const mockResult = createMockClaimResult(100);
+      const mockHistory = createMockHistory();
+      mockClaimStream
+        .mockResolvedValueOnce({ result: mockResult, history: mockHistory })
+        .mockResolvedValueOnce({
+          result: { ...mockResult, claimedAmount: 50 },
+          history: mockHistory,
+        });
+
+      const onSuccess = vi.fn();
+
+      const { result } = renderHook(() => useClaimBatch(onSuccess));
+
+      let claimable: { streamId: string; amount: number; assetCode: string }[] = [];
+      await act(async () => {
+        claimable = await result.current.fetchClaimable([
+          { streamId: "1", amount: 0, assetCode: "XLM" },
+          { streamId: "2", amount: 0, assetCode: "XLM" },
+        ]);
+      });
+
+      expect(mockGetClaimableBatch).toHaveBeenCalledWith(["1", "2"]);
+      expect(claimable).toHaveLength(2);
+      expect(result.current.state.totalClaimable).toBe(150);
+      expect(result.current.state.phase).toBe("ready");
+
+      await act(async () => {
+        await result.current.executeBatch(claimable, "GTEST123456789");
+      });
+
+      expect(mockClaimStream).toHaveBeenCalledTimes(2);
+      expect(mockClaimStream).toHaveBeenNthCalledWith(1, "1", "GTEST123456789", 100);
+      expect(mockClaimStream).toHaveBeenNthCalledWith(2, "2", "GTEST123456789", 50);
+      expect(onSuccess).toHaveBeenCalledTimes(2);
+      expect(result.current.state.phase).toBe("complete");
+      expect(result.current.state.successCount).toBe(2);
+    });
+
+    it("records failures in batch summary state", async () => {
+      mockGetClaimableBatch.mockResolvedValue({
+        amounts: { "1": 100 },
+        at: 1716812160,
+      });
+
+      mockClaimStream.mockRejectedValue(new Error("Network error"));
+
+      const onSuccess = vi.fn();
+      const { result } = renderHook(() => useClaimBatch(onSuccess));
+
+      let claimable: { streamId: string; amount: number; assetCode: string }[] = [];
+      await act(async () => {
+        claimable = await result.current.fetchClaimable([
+          { streamId: "1", amount: 0, assetCode: "XLM" },
+        ]);
+      });
+
+      await act(async () => {
+        await result.current.executeBatch(claimable, "GTEST123456789");
+      });
+
+      expect(result.current.state.failures).toEqual([
+        { streamId: "1", message: "Network error" },
+      ]);
+      expect(result.current.state.successCount).toBe(0);
+    });
   });
 
   it("clears error state on successful retry", async () => {

--- a/frontend/src/hooks/useStreamTableColumns.ts
+++ b/frontend/src/hooks/useStreamTableColumns.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type OptionalStreamColumn =
+  | "assetCode"
+  | "duration"
+  | "ratePerSecond"
+  | "pausedDuration";
+
+export const OPTIONAL_STREAM_COLUMNS: OptionalStreamColumn[] = [
+  "assetCode",
+  "duration",
+  "ratePerSecond",
+  "pausedDuration",
+];
+
+export const OPTIONAL_COLUMN_LABELS: Record<OptionalStreamColumn, string> = {
+  assetCode: "Asset",
+  duration: "Duration",
+  ratePerSecond: "Rate / sec",
+  pausedDuration: "Paused duration",
+};
+
+const STORAGE_KEY = "stream-table-columns";
+
+export type ColumnVisibility = Record<OptionalStreamColumn, boolean>;
+
+const DEFAULT_VISIBILITY: ColumnVisibility = {
+  assetCode: false,
+  duration: false,
+  ratePerSecond: false,
+  pausedDuration: false,
+};
+
+function loadVisibility(): ColumnVisibility {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_VISIBILITY };
+    const parsed = JSON.parse(raw) as Partial<ColumnVisibility>;
+    return { ...DEFAULT_VISIBILITY, ...parsed };
+  } catch {
+    return { ...DEFAULT_VISIBILITY };
+  }
+}
+
+function saveVisibility(visibility: ColumnVisibility): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(visibility));
+}
+
+export function useStreamTableColumns() {
+  const [visibility, setVisibility] = useState<ColumnVisibility>(loadVisibility);
+
+  useEffect(() => {
+    saveVisibility(visibility);
+  }, [visibility]);
+
+  const toggleColumn = useCallback((column: OptionalStreamColumn) => {
+    setVisibility((prev) => {
+      const next = { ...prev, [column]: !prev[column] };
+      saveVisibility(next);
+      return next;
+    });
+  }, []);
+
+  const isVisible = useCallback(
+    (column: OptionalStreamColumn) => visibility[column],
+    [visibility],
+  );
+
+  return { visibility, toggleColumn, isVisible };
+}

--- a/frontend/src/services/soroban.ts
+++ b/frontend/src/services/soroban.ts
@@ -80,3 +80,40 @@ export async function claimOnChain(
 
 export const claimStream = claimOnChain;
 
+export interface ClaimableBatchResponse {
+  amounts: Record<string, number>;
+  at: number;
+}
+
+/**
+ * Simulate on-chain claimable amounts for multiple streams via get_claimable_batch.
+ * Maximum 20 stream IDs per request (Soroban contract limit).
+ */
+export async function getClaimableBatch(
+  streamIds: string[],
+): Promise<ClaimableBatchResponse> {
+  const token = getAuthToken();
+
+  const response = await fetch(`${API_BASE}/streams/claimable/batch`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ streamIds }),
+  });
+
+  if (!response.ok) {
+    let message = `Failed to fetch claimable batch (${response.status})`;
+    try {
+      const body = (await response.json()) as { error?: string };
+      if (body.error) message = body.error;
+    } catch {
+      // ignore JSON parse errors
+    }
+    throw new Error(message);
+  }
+
+  return response.json() as Promise<ClaimableBatchResponse>;
+}
+

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,9 +2,52 @@ import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 
+/** Report-only first; set VITE_CSP_ENFORCE=true to send Content-Security-Policy instead. */
+const CSP_POLICY =
+  "default-src 'self'; connect-src 'self' https://rpc-futurenet.stellar.org";
+
+const cspHeaderName =
+  process.env.VITE_CSP_ENFORCE === 'true'
+    ? 'Content-Security-Policy'
+    : 'Content-Security-Policy-Report-Only';
+
+const securityHeaders = {
+  [cspHeaderName]: CSP_POLICY,
+};
+
 export default defineConfig({
   plugins: [
     react(),
+    {
+      name: 'content-security-policy',
+      transformIndexHtml(html) {
+        return {
+          html,
+          tags: [
+            {
+              tag: 'meta',
+              attrs: {
+                'http-equiv': cspHeaderName,
+                content: CSP_POLICY,
+              },
+              injectTo: 'head',
+            },
+          ],
+        };
+      },
+      configureServer(server) {
+        server.middlewares.use((_req, res, next) => {
+          res.setHeader(cspHeaderName, CSP_POLICY);
+          next();
+        });
+      },
+      configurePreviewServer(server) {
+        server.middlewares.use((_req, res, next) => {
+          res.setHeader(cspHeaderName, CSP_POLICY);
+          next();
+        });
+      },
+    },
     VitePWA({
       registerType: 'autoUpdate',
       workbox: {
@@ -68,9 +111,13 @@ export default defineConfig({
   ],
   server: {
     port: 3000,
+    headers: securityHeaders,
     proxy: {
       '/api': 'http://localhost:3001',
     },
+  },
+  preview: {
+    headers: securityHeaders,
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

Implements four related improvements for Stellar Stream:

- **#451 — Batch claim hook:** Adds `useClaimBatch` with `get_claimable_batch` simulation via `POST /api/streams/claimable/batch`, a summary modal (“Claim X across N streams”), sequential on-chain claims, progress UI, per-success toasts, and a failure summary in the modal. Recipient dashboard gets a **Claim all** action when multiple active streams exist.

- **#458 — StreamsTable column visibility:** Adds a toolbar column toggle (optional: asset, duration, rate/sec, paused duration). Required columns (id, sender, recipient, progress, status, actions) stay visible. Preferences persist in `localStorage` under `stream-table-columns`.

- **#443 — Content-Security-Policy:** Injects `default-src 'self'; connect-src 'self' https://rpc-futurenet.stellar.org` via Vite (meta tag + HTTP headers). Uses **report-only** mode by default; set `VITE_CSP_ENFORCE=true` to enforce. Documented in `SECURITY.md`.

- **#463 — Reconciliation interval:** `RECONCILIATION_INTERVAL_MS` is validated in `validateEnv` (default 60,000ms, minimum 10,000ms) and passed to `startReconciliationJob`. Documented in `backend/.env.example`.

Also restores the corrupted `GET /api/recipients/:accountId/streams` route and rebuilds `StreamsTable.tsx` from a working baseline.

Closes #451
Closes #458
Closes #443
Closes #463

## Test plan

- [ ] `cd frontend && npx vitest run src/hooks/useClaimStream.test.ts src/components/StreamsTable.test.tsx`
- [ ] `cd backend && npx vitest run src/config/validateEnv.test.ts -t RECONCILIATION`
- [ ] Recipient dashboard: connect wallet with 2+ active streams → **Claim all** → confirm modal summary → verify progress and toasts
- [ ] Streams table: open **Columns** popover → toggle **Asset** → reload page → column still visible
- [ ] Dev server: inspect response headers for `Content-Security-Policy-Report-Only`
- [ ] Backend: set `RECONCILIATION_INTERVAL_MS=15000` → confirm startup log shows 15000ms interval
- [ ] Backend: set `RECONCILIATION_INTERVAL_MS=5000` → confirm process exits with validation error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Batch claiming: Claim all active streams simultaneously using the "Claim all" action with a confirmation modal
  * Customizable stream table: Toggle optional column visibility (asset, duration, rate per second, paused duration) with persistent preferences

* **Improvements**
  * Enhanced security posture with Content Security Policy implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->