### PR TITLE
docs: add CODEOWNERS for default review ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default code owners
+* @espcris05
+


### PR DESCRIPTION
Adding a CODEOWNERS file so that all new pull requests default to @espcris05 for review.

Part of ongoing Stellar Wave contribution sprint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code ownership configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->