### PR TITLE
chore: add stale bot config to auto-close inactive issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Only issues with these labels will be marked as stale
+onlyLabels: []
+# Set to true to ignore issues in a project
+exemptProjects: true
+# Set to true to ignore issues in a milestone
+exemptMilestones: true
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed in 14 days if no further activity occurs.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default code owners
+* @espcris05
+


### PR DESCRIPTION
Adding a stale bot configuration to automatically mark issues as stale after 60 days of inactivity and close them after 14 more days.

This helps maintain repo hygiene for the Stellar Wave project.