### PR TITLE
feat : Add validation/schemas.test.ts edge case coverage

### DIFF
--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -512,22 +512,22 @@ describe("POST /api/streams", () => {
     );
   });
 
-  it("returns 400 when durationSeconds is below the minimum", async () => {
-    const response = await request(app)
-      .post("/api/streams")
-      .set("Authorization", "Bearer mock_token")
-      .send({
-        sender: SENDER_A,
-        recipient: RECIPIENT_1,
-        assetCode: "USDC",
-        totalAmount: 100,
-        durationSeconds: 59,
-      });
+it("returns 400 when durationSeconds is zero", async () => {
+     const response = await request(app)
+       .post("/api/streams")
+       .set("Authorization", "Bearer mock_token")
+       .send({
+         sender: SENDER_A,
+         recipient: RECIPIENT_1,
+         assetCode: "USDC",
+         totalAmount: 100,
+         durationSeconds: 0,
+       });
 
-    expect(response.status).toBe(400);
-    expect(response.body.code).toBe("VALIDATION_ERROR");
-    expect(response.body.error).toContain("durationSeconds must be at least 60 seconds");
-  });
+     expect(response.status).toBe(400);
+     expect(response.body.code).toBe("VALIDATION_ERROR");
+     expect(response.body.error).toContain("durationSeconds must be at least 1 second");
+   });
 
   it("returns 400 when assetCode is not allowed", async () => {
     const response = await request(app)

--- a/backend/src/validation/schemas.test.ts
+++ b/backend/src/validation/schemas.test.ts
@@ -3,6 +3,9 @@ import {
     stellarAccountIdSchema,
     webhookRegistrationSchema,
     isStellarPublicKey,
+    createStreamPayloadSchema,
+    totalAmountSchema,
+    durationSecondsSchema,
 } from "./schemas";
 
 describe("Stellar Account ID Validation", () => {
@@ -153,10 +156,174 @@ describe("Webhook Registration Schema", () => {
     it("should accept all valid event types", () => {
         const payload = {
             url: "https://example.com/webhooks",
-            events: ["created", "claimed", "canceled", "start_time_updated"],
+            events: ["created", "claimed", "canceled", "start_time_updated", "paused", "resumed"],
         };
 
         const result = webhookRegistrationSchema.safeParse(payload);
         expect(result.success).toBe(true);
+    });
+});
+
+describe("Create Stream Payload Schema", () => {
+    const validBasePayload = {
+        sender: "GCLJJD5FHTSEBHFXAA3BBTODUJ4RXDK6B3OSVNKY6TUHF76AQQT2WNFC",
+        recipient: "GBLHBYX72TJQH5EVPUN4ATAREH6TWYXQAH37MHNCVQG2NKLHFDSMFS3D",
+        assetCode: "USDC",
+        totalAmount: 100,
+        durationSeconds: 3600,
+    };
+
+    it("should accept valid stream creation payload", () => {
+        const result = createStreamPayloadSchema.safeParse(validBasePayload);
+        expect(result.success).toBe(true);
+    });
+
+    it("should accept stream with startAt in the future", () => {
+        const payload = {
+            ...validBasePayload,
+            startAt: Math.floor(Date.now() / 1000) + 3600,
+        };
+
+        const result = createStreamPayloadSchema.safeParse(payload);
+        expect(result.success).toBe(true);
+    });
+
+    it("should reject durationSeconds = 0", () => {
+        const payload = { ...validBasePayload, durationSeconds: 0 };
+        const result = createStreamPayloadSchema.safeParse(payload);
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].path).toContain("durationSeconds");
+    });
+
+    it("should accept durationSeconds = 1 (minimum valid)", () => {
+        const payload = { ...validBasePayload, durationSeconds: 1 };
+        const result = createStreamPayloadSchema.safeParse(payload);
+        expect(result.success).toBe(true);
+    });
+
+    it("should reject totalAmount with more than 7 decimal places", () => {
+        const payload = { ...validBasePayload, totalAmount: 1.12345678 };
+        const result = createStreamPayloadSchema.safeParse(payload);
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toContain("7 decimal places");
+    });
+
+    it("should accept totalAmount with exactly 7 decimal places", () => {
+        const payload = { ...validBasePayload, totalAmount: 1.1234567 };
+        const result = createStreamPayloadSchema.safeParse(payload);
+        expect(result.success).toBe(true);
+    });
+
+    it("should reject recipient same as sender", () => {
+        const payload = { ...validBasePayload, recipient: validBasePayload.sender };
+        const result = createStreamPayloadSchema.safeParse(payload);
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].path).toContain("recipient");
+        expect(result.error?.issues[0].message).toContain("differ");
+    });
+
+    it("should reject startAt more than 1 year in future", () => {
+        const payload = {
+            ...validBasePayload,
+            startAt: Math.floor(Date.now() / 1000) + (365 * 24 * 60 * 60) + 1,
+        };
+        const result = createStreamPayloadSchema.safeParse(payload);
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].path).toContain("startAt");
+        expect(result.error?.issues[0].message).toContain("1 year");
+    });
+
+    it("should accept startAt exactly 1 year in future", () => {
+        const payload = {
+            ...validBasePayload,
+            startAt: Math.floor(Date.now() / 1000) + (365 * 24 * 60 * 60),
+        };
+        const result = createStreamPayloadSchema.safeParse(payload);
+        expect(result.success).toBe(true);
+    });
+
+    it("should reject negative totalAmount", () => {
+        const payload = { ...validBasePayload, totalAmount: -100 };
+        const result = createStreamPayloadSchema.safeParse(payload);
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject zero totalAmount", () => {
+        const payload = { ...validBasePayload, totalAmount: 0 };
+        const result = createStreamPayloadSchema.safeParse(payload);
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject missing required fields", () => {
+        const { sender, ...payloadWithoutSender } = validBasePayload;
+        const result = createStreamPayloadSchema.safeParse(payloadWithoutSender);
+        expect(result.success).toBe(false);
+    });
+});
+
+describe("Total Amount Schema", () => {
+    it("should reject amount with more than 7 decimal places", () => {
+        const result = totalAmountSchema.safeParse(1.12345678);
+        expect(result.success).toBe(false);
+    });
+
+    it("should accept amount with exactly 7 decimal places", () => {
+        const result = totalAmountSchema.safeParse(1.1234567);
+        expect(result.success).toBe(true);
+    });
+
+    it("should accept integer amounts", () => {
+        const result = totalAmountSchema.safeParse(100);
+        expect(result.success).toBe(true);
+    });
+
+    it("should reject non-positive amounts", () => {
+        const result = totalAmountSchema.safeParse(0);
+        expect(result.success).toBe(false);
+        const result2 = totalAmountSchema.safeParse(-1);
+        expect(result2.success).toBe(false);
+    });
+
+    it("should accept string numbers", () => {
+        const result = totalAmountSchema.safeParse("123.45");
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data).toBe(123.45);
+        }
+    });
+});
+
+describe("Duration Seconds Schema", () => {
+    it("should reject zero durationSeconds", () => {
+        const result = durationSecondsSchema.safeParse(0);
+        expect(result.success).toBe(false);
+    });
+
+    it("should accept 1 second as minimum valid duration", () => {
+        const result = durationSecondsSchema.safeParse(1);
+        expect(result.success).toBe(true);
+    });
+
+    it("should accept standard durations", () => {
+        const result = durationSecondsSchema.safeParse(3600);
+        expect(result.success).toBe(true);
+    });
+
+    it("should reject non-integer durations", () => {
+        const result = durationSecondsSchema.safeParse(1.5);
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject negative durations", () => {
+        const result = durationSecondsSchema.safeParse(-100);
+        expect(result.success).toBe(false);
+    });
+
+    it("should accept string numbers", () => {
+        const result = durationSecondsSchema.safeParse("3600");
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data).toBe(3600);
+        }
     });
 });

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -34,12 +34,19 @@ export const assetCodeSchema = z
 export const totalAmountSchema = z.coerce
   .number()
   .finite("Total amount must be a valid number.")
-  .positive("Amount must be greater than zero.");
+  .positive("Amount must be greater than zero.")
+  .refine(
+    (value) => {
+      const decimalStr = value.toString().split(".")[1];
+      return !decimalStr || decimalStr.length <= 7;
+    },
+    "Amount cannot have more than 7 decimal places."
+  );
 
 export const durationSecondsSchema = z.coerce
   .number()
   .int("durationSeconds must be a whole number of seconds.")
-  .min(60, "durationSeconds must be at least 60 seconds.");
+  .min(1, "durationSeconds must be at least 1 second.");
 
 export const unixTimestampSchema = z.coerce
   .number()
@@ -63,6 +70,16 @@ export const createStreamPayloadSchema = z
         message: "Recipient must differ from the sender account.",
       });
     }
+    if (payload.startAt !== undefined) {
+      const maxFutureTimestamp = Math.floor(Date.now() / 1000) + 365 * 24 * 60 * 60;
+      if (payload.startAt > maxFutureTimestamp) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["startAt"],
+          message: "startAt cannot be more than 1 year in the future.",
+        });
+      }
+    }
   });
 
 export function createStreamPayloadWithAllowedAssetsSchema(
@@ -83,6 +100,15 @@ export function createStreamPayloadWithAllowedAssetsSchema(
 
 export const updateStreamStartAtSchema = z.object({
   startAt: unixTimestampSchema,
+}).superRefine((payload, ctx) => {
+  const maxFutureTimestamp = Math.floor(Date.now() / 1000) + 365 * 24 * 60 * 60;
+  if (payload.startAt > maxFutureTimestamp) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["startAt"],
+      message: "startAt cannot be more than 1 year in the future.",
+    });
+  }
 });
 
 const VALID_EVENT_TYPES = ["created", "claimed", "canceled", "start_time_updated", "paused", "resumed"] as const;


### PR DESCRIPTION
# Closes #466 
## Summary
Extended `schemas.test.ts` with boundary and negative test cases for all stream creation input schema fields as specified.

## Changes

### Schema Updates (backend/src/validation/schemas.ts)
- **totalAmountSchema**: Added validation to reject amounts with more than 7 decimal places
- **durationSecondsSchema**: Changed minimum from 60 seconds to 1 second (per acceptance criteria)
- **createStreamPayloadSchema**: Added validation to reject startAt more than 1 year in future
- **updateStreamStartAtSchema**: Added same 1-year future validation for startAt

### Test Updates (backend/src/validation/schemas.test.ts)
- Added "Create Stream Payload Schema" test suite with:
  - durationSeconds = 0 → validation error
  - durationSeconds = 1 → accepted (minimum valid)
  - totalAmount with more than 7 decimal places → error
  - totalAmount with exactly 7 decimal places → accepted
  - recipient address same as sender → error
  - startAt more than 1 year in future → error
  - startAt exactly 1 year in future → accepted (boundary)
  - Negative and zero totalAmount tests
  - Missing required fields test

- Added "Total Amount Schema" test suite with:
  - Decimal precision validation tests
  - String number coercion tests

- Added "Duration Seconds Schema" test suite with:
  - Zero rejection test
  - Minimum value acceptance test
  - Non-integer rejection test
  - Negative value rejection test

### Integration Test Update (backend/src/index.test.ts)
- Updated existing test to check for new error message for durationSeconds = 0

## Acceptance Criteria
- [x] Test: durationSeconds = 0 → validation error
- [x] Test: durationSeconds = 1 → accepted (minimum valid)
- [x] Test: totalAmount with more than 7 decimal places → error
- [x] Test: recipient address same as sender → error
- [x] Test: startAt more than 1 year in future → error
- [x] All new tests pass in CI