### PR TITLE
Add concurrent claim test to verify double-spend prevention

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1250,7 +1250,19 @@ app.post(
       const db = (await import("./services/db")).getDb();
       const { recordEventWithDb } = await import("./services/eventHistory");
       const now = Math.floor(Date.now() / 1000);
+
+      // Guard against double-spend: check and write inside one atomic transaction.
+      let alreadyClaimed = false;
       db.transaction(() => {
+        const existing = db
+          .prepare(
+            `SELECT 1 FROM stream_events WHERE stream_id = ? AND event_type = 'claimed' LIMIT 1`,
+          )
+          .get(stream.id);
+        if (existing) {
+          alreadyClaimed = true;
+          return;
+        }
         recordEventWithDb(
           db,
           stream.id,
@@ -1261,6 +1273,13 @@ app.post(
           { assetCode: stream.assetCode },
         );
       })();
+
+      if (alreadyClaimed) {
+        sendApiError(req, res, 409, "Stream has already been claimed.", {
+          code: "ALREADY_CLAIMED",
+        });
+        return;
+      }
 
       const history = await import("./services/eventHistory").then((m) =>
         m.getStreamHistory(stream.id),

--- a/backend/src/integration.test.ts
+++ b/backend/src/integration.test.ts
@@ -4,6 +4,8 @@ import { app } from "./index";
 import { initDb, getDb } from "./services/db";
 import { initCache, getCache } from "./services/cache";
 import { Keypair } from "@stellar/stellar-sdk";
+import jwt from "jsonwebtoken";
+import { getJwtSecret } from "./services/auth";
 import path from "path";
 import fs from "fs";
 
@@ -837,6 +839,106 @@ describe("Backend Integration Tests", () => {
 
         expect(response.status).toBe(400);
         expect(response.body.error).toContain("status must be one of");
+      });
+    });
+
+    describe("POST /api/streams/:id/claim", () => {
+      let recipientKeypair: ReturnType<typeof Keypair.random>;
+      let senderKeypair: ReturnType<typeof Keypair.random>;
+      let claimStreamId: string;
+      let recipientToken: string;
+
+      beforeEach(() => {
+        recipientKeypair = Keypair.random();
+        senderKeypair = Keypair.random();
+        const now = Math.floor(Date.now() / 1000);
+        claimStreamId = "100";
+
+        const db = getDb();
+        db.prepare(`
+          INSERT INTO streams (id, sender, recipient, asset_code, total_amount, duration_seconds, start_at, created_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `).run(
+          claimStreamId,
+          senderKeypair.publicKey(),
+          recipientKeypair.publicKey(),
+          "USDC",
+          1000,
+          3600,
+          now - 1800,
+          now - 1800,
+        );
+
+        recipientToken = jwt.sign(
+          { accountId: recipientKeypair.publicKey() },
+          getJwtSecret(),
+          { expiresIn: "1h" },
+        );
+      });
+
+      it("should allow the recipient to claim vested tokens", async () => {
+        const response = await request(app)
+          .post(`/api/streams/${claimStreamId}/claim`)
+          .set("Authorization", `Bearer ${recipientToken}`);
+
+        expect(response.status).toBe(200);
+        expect(response.body.result.claimedAmount).toBeGreaterThan(0);
+        expect(response.body.result.assetCode).toBe("USDC");
+        expect(response.body.result.txHash).toMatch(/^local-/);
+      });
+
+      it("should return 403 when a non-recipient tries to claim", async () => {
+        const nonRecipientToken = jwt.sign(
+          { accountId: senderKeypair.publicKey() },
+          getJwtSecret(),
+          { expiresIn: "1h" },
+        );
+
+        const response = await request(app)
+          .post(`/api/streams/${claimStreamId}/claim`)
+          .set("Authorization", `Bearer ${nonRecipientToken}`);
+
+        expect(response.status).toBe(403);
+        expect(response.body.code).toBe("FORBIDDEN");
+      });
+
+      it("should reject a second sequential claim on the same stream", async () => {
+        const first = await request(app)
+          .post(`/api/streams/${claimStreamId}/claim`)
+          .set("Authorization", `Bearer ${recipientToken}`);
+        expect(first.status).toBe(200);
+
+        const second = await request(app)
+          .post(`/api/streams/${claimStreamId}/claim`)
+          .set("Authorization", `Bearer ${recipientToken}`);
+        expect(second.status).toBe(409);
+        expect(second.body.code).toBe("ALREADY_CLAIMED");
+
+        const db = getDb();
+        const claimEvents = db
+          .prepare(`SELECT * FROM stream_events WHERE stream_id = ? AND event_type = 'claimed'`)
+          .all(claimStreamId);
+        expect(claimEvents).toHaveLength(1);
+      });
+
+      it("should prevent double-spend under concurrent claims", async () => {
+        const [res1, res2] = await Promise.all([
+          request(app)
+            .post(`/api/streams/${claimStreamId}/claim`)
+            .set("Authorization", `Bearer ${recipientToken}`),
+          request(app)
+            .post(`/api/streams/${claimStreamId}/claim`)
+            .set("Authorization", `Bearer ${recipientToken}`),
+        ]);
+
+        const statuses = [res1.status, res2.status].sort((a, b) => a - b);
+        expect(statuses).toEqual([200, 409]);
+
+        const db = getDb();
+        const claimEvents = db
+          .prepare(`SELECT * FROM stream_events WHERE stream_id = ? AND event_type = 'claimed'`)
+          .all(claimStreamId);
+        expect(claimEvents).toHaveLength(1);
       });
     });
   });

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -48,6 +48,10 @@ if (!jwtSecret) {
   logger.warn(
     "JWT_SECRET not set — using ephemeral secret. All tokens will be invalidated on restart.",
   );
+} else {
+  logger.warn(
+    "JWT_SECRET is configured. Rotating this secret will invalidate all existing tokens and force all users to re-authenticate.",
+  );
 }
 
 export function getJwtSecret() {


### PR DESCRIPTION
closes #335
closes #355
closes #343
closes #354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate claim submissions from creating multiple “claimed” records. Repeat claims now return a conflict response, and concurrent requests are handled safely.
  * Added clearer warning logs when JWT settings are configured, helping explain why some tokens may stop working.

* **Tests**
  * Expanded end-to-end coverage for claim flows, including successful claims, unauthorized attempts, повторные claims, and concurrent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->