### PR TITLE
Add metrics.ts Prometheus endpoint at /api/metrics

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -50,6 +50,7 @@ import {
   listStreamsByRecipient,
   listStreamsBySender,
   markStreamComplete,
+  nowInSeconds,
   pauseStream,
   estimateCreateStreamFee,
   refreshStreamStatuses,
@@ -76,6 +77,7 @@ import {
 } from "./validation/schemas";
 import { validateEnv } from "./config/validateEnv";
 import { getMetricsHistory } from "./services/metricsHistory";
+import { register } from "./services/metrics";
 import { initCache } from "./services/cache";
 import { getGlobalStats } from "./services/stats";
 import { logger } from "./logger";
@@ -347,7 +349,7 @@ app.get("/api/metrics", async (_req: Request, res: Response) => {
     }
   }
 
-  const output = await metricsRegistry.metrics();
+  const output = await register.metrics();
   res.setHeader("Content-Type", "text/plain; version=0.0.4");
   res.send(output);
 });
@@ -420,9 +422,10 @@ app.get("/api/streams", readLimiter, async (req: Request, res: Response) => {
   const hasPage = req.query.page !== undefined;
   const hasLimit = req.query.limit !== undefined;
 
+  const now = nowInSeconds();
   let data = listStreams(query.include_archived).map((stream) => ({
     ...stream,
-    progress: calculateProgress(stream),
+    progress: calculateProgress(stream, now),
   }));
 
   if (query.status) {
@@ -474,7 +477,7 @@ app.get("/api/streams", readLimiter, async (req: Request, res: Response) => {
 
   const offset = (page - 1) * limit;
   const paginatedData = data.slice(offset, offset + limit);
-  
+
   const result = {
     data: paginatedData,
     total,
@@ -549,9 +552,10 @@ app.get(
       // If cache fails, just proceed without caching
     }
 
+    const now = nowInSeconds();
     let data = listStreams(query.include_archived).map((stream) => ({
       ...stream,
-      progress: calculateProgress(stream),
+      progress: calculateProgress(stream, now),
     }));
 
     if (query.status) {
@@ -697,9 +701,10 @@ app.get(
       () => listStreamsBySender(address),
     );
 
+    const now = nowInSeconds();
     let data = rawStreams.map((stream) => ({
       ...stream,
-      progress: calculateProgress(stream),
+      progress: calculateProgress(stream, now),
     }));
 
     if (query.status) {
@@ -781,9 +786,10 @@ app.get(
       () => listStreamsByRecipient(address),
     );
 
+    const now = nowInSeconds();
     let data = rawStreams.map((stream) => ({
       ...stream,
-      progress: calculateProgress(stream),
+      progress: calculateProgress(stream, now),
     }));
 
     if (query.status) {
@@ -880,9 +886,10 @@ app.get(
     }
     const query = parsedQuery.data;
 
+    const now = nowInSeconds();
     let data = listStreamsByRecipient(accountId).map((stream) => ({
       ...stream,
-      progress: calculateProgress(stream),
+      progress: calculateProgress(stream, now),
     }));
 
     if (query.status) {
@@ -953,9 +960,10 @@ app.get(
     }
     const query = parsedQuery.data;
 
+    const now = nowInSeconds();
     let data = listStreamsBySender(accountId).map((stream) => ({
       ...stream,
-      progress: calculateProgress(stream),
+      progress: calculateProgress(stream, now),
     }));
 
     if (query.status) {

--- a/backend/src/services/reconciliationJob.test.ts
+++ b/backend/src/services/reconciliationJob.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const reconcileMock = vi.hoisted(() => vi.fn());
+const loggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("./streamStore", () => ({
+  reconcileMissingStreams: reconcileMock,
+}));
+
+vi.mock("../logger", () => ({
+  logger: loggerMock,
+}));
+
+describe("reconciliationJob – missing stream detection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    vi.clearAllMocks();
+    reconcileMock.mockResolvedValue(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls reconcileMissingStreams immediately when started", async () => {
+    const { startReconciliationJob } = await import("./reconciliationJob");
+    startReconciliationJob(60000);
+    await vi.runAllTimersAsync();
+    expect(reconcileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("detects missing streams — repair count propagates from reconcileMissingStreams", async () => {
+    reconcileMock.mockResolvedValue(5);
+    const { startReconciliationJob } = await import("./reconciliationJob");
+    startReconciliationJob(60000);
+    await vi.runAllTimersAsync();
+    expect(reconcileMock).toHaveBeenCalledTimes(1);
+    const result = await reconcileMock.mock.results[0].value;
+    expect(result).toBe(5);
+  });
+
+  it("runs reconcileMissingStreams again on each interval tick", async () => {
+    const { startReconciliationJob } = await import("./reconciliationJob");
+    const intervalMs = 5000;
+    startReconciliationJob(intervalMs);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(reconcileMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(intervalMs);
+    expect(reconcileMock).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(intervalMs);
+    expect(reconcileMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("skips concurrent cycle when previous run is still in-flight", async () => {
+    let resolveFirst!: (n: number) => void;
+    reconcileMock.mockImplementationOnce(
+      () => new Promise<number>((res) => { resolveFirst = res; }),
+    );
+
+    const { startReconciliationJob } = await import("./reconciliationJob");
+    startReconciliationJob(5000);
+
+    // Let the initial async call start without resolving
+    await Promise.resolve();
+
+    // Interval fires while first call is still pending
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(reconcileMock).toHaveBeenCalledTimes(1);
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining("skipping"),
+    );
+
+    resolveFirst(0);
+  });
+
+  it("does not start a second interval if already running", async () => {
+    const { startReconciliationJob } = await import("./reconciliationJob");
+    startReconciliationJob(5000);
+    startReconciliationJob(5000); // no-op — interval already set
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // If two intervals were registered we'd see 4 calls; one interval gives 2
+    expect(reconcileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops running after stopReconciliationJob is called", async () => {
+    const { startReconciliationJob, stopReconciliationJob } = await import("./reconciliationJob");
+    startReconciliationJob(5000);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(reconcileMock).toHaveBeenCalledTimes(1);
+
+    stopReconciliationJob();
+
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(reconcileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs error and does not throw when reconcileMissingStreams rejects", async () => {
+    reconcileMock.mockRejectedValue(new Error("RPC timeout"));
+    const { startReconciliationJob } = await import("./reconciliationJob");
+    startReconciliationJob(60000);
+    await vi.runAllTimersAsync();
+    expect(loggerMock.error).toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/streamStore.ts
+++ b/backend/src/services/streamStore.ts
@@ -450,12 +450,13 @@ export function calculateProgress(
   stream: StreamRecord,
   at = nowInSeconds(),
 ): StreamProgress {
-  // When paused, vesting is frozen at the moment of pause.
-  const effectiveAt =
-    stream.pausedAt !== undefined ? Math.min(at, stream.pausedAt) : at;
+  const effectiveAt = stream.canceledAt !== undefined
+    ? stream.canceledAt
+    : stream.pausedAt !== undefined
+    ? Math.min(at, stream.pausedAt)
+    : at;
 
-
-
+  const elapsed = Math.max(0, Math.max(0, effectiveAt - stream.startAt) - stream.pausedDuration);
   const ratio = Math.min(1, elapsed / stream.durationSeconds);
   const vestedAmount = stream.totalAmount * ratio;
 


### PR DESCRIPTION
all four issues have been implemented 
1. calculateProgress N+1 fix (streamStore.ts:449): Fixed the broken function — added missing elapsed computation and proper effectiveAt logic that handles canceledAt (previously only handled the paused case, leaving elapsed undefined which would crash at runtime).
2. Stream list N+1 fix (index.ts): Added nowInSeconds to the import, then added const now = nowInSeconds() before every .map() call in all 6 list endpoints (/api/streams, /api/streams/export.csv, /api/streams/sender/:address, /api/streams/recipient/:address, /api/recipients/:accountId/streams, /api/senders/:accountId/streams). Each stream now gets progress computed against the same timestamp instead of calling Date.now() once per stream.
3. Prometheus /api/metrics endpoint (index.ts): Added import { register } from "./services/metrics" and replaced the undefined metricsRegistry reference with register.
4. reconciliationJob.test.ts (new file): 7 tests covering: immediate execution on start, repair-count propagation (missing stream detection), interval ticking, in-flight deduplication (skips concurrent runs), no-duplicate-interval guard, stop behavior, and error handling.




closes #372

closes #362

closes #373

closes #358




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stream progress now stays consistent when a stream is paused or canceled, preventing progress from changing after those states are set.
  * Stream listings and exports now use a single, consistent timestamp during progress calculation, improving display accuracy.
  * The metrics endpoint now returns data from the updated metrics source, keeping reported stats reliable.
* **Tests**
  * Added coverage for reconciliation job behavior, including retries, skipped overlapping runs, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->