### PR TITLE
feat: multi-status filter, date range filter, stream transfer event, and Soroban retry backoff

### DIFF
--- a/backend/src/services/streamStore.ts
+++ b/backend/src/services/streamStore.ts
@@ -19,6 +19,9 @@ import { triggerWebhook } from "./webhook";
 import { initCache, getCache } from "./cache";
 import { resetStatsCache } from "./stats";
 import { logger } from "../logger";
+import { retryWithBackoff, SorobanSubmitError } from "../utils/sorobanRetry";
+
+export { SorobanSubmitError };
 
 export type StreamStatus = "scheduled" | "active" | "paused" | "completed" | "canceled";
 
@@ -209,34 +212,6 @@ async function invalidateCache(pattern?: string): Promise<void> {
   }
 }
 
-async function retryWithBackoff<T>(
-  fn: () => Promise<T>,
-  maxAttempts = 3,
-): Promise<T> {
-  let lastError: any;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      lastError = err;
-      const message = String(err).toLowerCase();
-      const isRetryable =
-        message.includes("timeout") ||
-        message.includes("network") ||
-        message.includes("econnrefused") ||
-        message.includes("econnreset");
-
-      if (!isRetryable || attempt === maxAttempts) {
-        throw err;
-      }
-
-      const delayMs = Math.pow(2, attempt - 1) * 1000;
-      logger.info({ err, attempt, delayMs }, "retryable operation failed, retrying");
-      await new Promise((r) => setTimeout(r, delayMs));
-    }
-  }
-  throw lastError;
-}
 
 function getSorobanContext():
   | {

--- a/backend/src/utils/sorobanRetry.test.ts
+++ b/backend/src/utils/sorobanRetry.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { retryWithBackoff, SorobanSubmitError } from "./sorobanRetry";
+import { logger } from "../logger";
+
+function makeError(message: string, status?: number): Error {
+  return Object.assign(new Error(message), status !== undefined ? { status } : {});
+}
+
+describe("retryWithBackoff", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns result on first attempt without retrying", async () => {
+    const fn = vi.fn().mockResolvedValue("success");
+    const result = await retryWithBackoff(fn);
+    expect(result).toBe("success");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 503 and succeeds on second attempt", async () => {
+    const err = makeError("Service Unavailable", 503);
+    const fn = vi.fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("ok");
+
+    const promise = retryWithBackoff(fn);
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on 504 and succeeds on second attempt", async () => {
+    const err = makeError("Gateway Timeout", 504);
+    const fn = vi.fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("ok");
+
+    const promise = retryWithBackoff(fn);
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on ECONNREFUSED network error and succeeds", async () => {
+    const err = makeError("connect ECONNREFUSED 127.0.0.1:443");
+    const fn = vi.fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("data");
+
+    const promise = retryWithBackoff(fn);
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toBe("data");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on ECONNRESET network error", async () => {
+    const err = makeError("socket hang up ECONNRESET");
+    const fn = vi.fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("data");
+
+    const promise = retryWithBackoff(fn);
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toBe("data");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on timeout error", async () => {
+    const err = makeError("request timeout");
+    const fn = vi.fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("data");
+
+    const promise = retryWithBackoff(fn);
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toBe("data");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on 400 error", async () => {
+    const err = makeError("Bad Request", 400);
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(retryWithBackoff(fn)).rejects.toThrow("Bad Request");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry on 401 error", async () => {
+    const err = makeError("Unauthorized", 401);
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(retryWithBackoff(fn)).rejects.toThrow("Unauthorized");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry on 422 error", async () => {
+    const err = makeError("Unprocessable Entity", 422);
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(retryWithBackoff(fn)).rejects.toThrow("Unprocessable Entity");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies exponential delays: 1s then 2s then 4s between attempts", async () => {
+    const err = makeError("Service Unavailable", 503);
+    const fn = vi.fn()
+      .mockRejectedValueOnce(err)
+      .mockRejectedValueOnce(err)
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("ok");
+
+    const promise = retryWithBackoff(fn);
+
+    // Initial attempt fires immediately, then 1s delay
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    // After 2s more (3s total): 3rd attempt
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(fn).toHaveBeenCalledTimes(3);
+
+    // After 4s more (7s total): 4th attempt
+    await vi.advanceTimersByTimeAsync(4000);
+    await promise;
+    expect(fn).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not retry before the delay elapses", async () => {
+    const err = makeError("Service Unavailable", 503);
+    const fn = vi.fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("ok");
+
+    const promise = retryWithBackoff(fn);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(500);
+    await promise;
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs at warn level on each retry with attempt number", async () => {
+    const err = makeError("Service Unavailable", 503);
+    const fn = vi.fn()
+      .mockRejectedValueOnce(err)
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue("ok");
+
+    const promise = retryWithBackoff(fn);
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+    expect((logger.warn as any).mock.calls[0][0]).toMatchObject({ attempt: 1 });
+    expect((logger.warn as any).mock.calls[0][1]).toContain("attempt 1");
+    expect((logger.warn as any).mock.calls[1][0]).toMatchObject({ attempt: 2 });
+    expect((logger.warn as any).mock.calls[1][1]).toContain("attempt 2");
+  });
+
+  it("throws SorobanSubmitError after exhausting all retries", async () => {
+    const err = makeError("Service Unavailable", 503);
+    const fn = vi.fn().mockRejectedValue(err);
+
+    const promise = retryWithBackoff(fn);
+    await Promise.all([
+      expect(promise).rejects.toBeInstanceOf(SorobanSubmitError),
+      vi.advanceTimersByTimeAsync(7000),
+    ]);
+    expect(fn).toHaveBeenCalledTimes(4);
+  });
+
+  it("SorobanSubmitError includes statusCode and retryAfter suggestion", async () => {
+    const err = makeError("Service Unavailable", 503);
+    const fn = vi.fn().mockRejectedValue(err);
+
+    const promise = retryWithBackoff(fn);
+    let caughtError!: SorobanSubmitError;
+    await Promise.all([
+      promise.catch((e) => { caughtError = e as SorobanSubmitError; }),
+      vi.advanceTimersByTimeAsync(7000),
+    ]);
+
+    expect(caughtError).toBeInstanceOf(SorobanSubmitError);
+    expect(caughtError.statusCode).toBe(503);
+    expect(caughtError.retryAfter).toBe(10);
+    expect(caughtError.message).toContain("3 retries");
+  });
+
+  it("SorobanSubmitError includes retryAfter for network error with no HTTP status", async () => {
+    const err = makeError("fetch failed");
+    const fn = vi.fn().mockRejectedValue(err);
+
+    const promise = retryWithBackoff(fn);
+    let caughtError!: SorobanSubmitError;
+    await Promise.all([
+      promise.catch((e) => { caughtError = e as SorobanSubmitError; }),
+      vi.advanceTimersByTimeAsync(7000),
+    ]);
+
+    expect(caughtError).toBeInstanceOf(SorobanSubmitError);
+    expect(caughtError.retryAfter).toBe(10);
+    expect(caughtError.statusCode).toBeUndefined();
+  });
+});

--- a/backend/src/utils/sorobanRetry.ts
+++ b/backend/src/utils/sorobanRetry.ts
@@ -1,0 +1,92 @@
+import { logger } from "../logger";
+
+export class SorobanSubmitError extends Error {
+  public readonly statusCode?: number;
+  public readonly retryAfter: number;
+
+  constructor(message: string, statusCode?: number, retryAfter = 10) {
+    super(message);
+    this.name = "SorobanSubmitError";
+    this.statusCode = statusCode;
+    this.retryAfter = retryAfter;
+  }
+}
+
+const RETRY_DELAYS_MS = [1000, 2000, 4000];
+
+function extractStatusCode(err: unknown): number | undefined {
+  if (err && typeof err === "object") {
+    const e = err as Record<string, any>;
+    return e["status"] ?? e["response"]?.["status"] ?? e["statusCode"];
+  }
+  return undefined;
+}
+
+function isRetryableError(err: unknown): boolean {
+  const statusCode = extractStatusCode(err);
+
+  if (statusCode !== undefined && statusCode >= 400 && statusCode < 500) {
+    return false;
+  }
+
+  if (statusCode === 503 || statusCode === 504) {
+    return true;
+  }
+
+  const msg = String(
+    err && typeof err === "object" ? (err as any).message ?? err : err,
+  ).toLowerCase();
+
+  return (
+    msg.includes("network") ||
+    msg.includes("timeout") ||
+    msg.includes("econnrefused") ||
+    msg.includes("econnreset") ||
+    msg.includes("fetch failed") ||
+    msg.includes("etimedout")
+  );
+}
+
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  maxRetries = 3,
+): Promise<T> {
+  let lastError: unknown;
+  const totalAttempts = maxRetries + 1;
+
+  for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+
+      if (!isRetryableError(err)) {
+        throw err;
+      }
+
+      if (attempt >= totalAttempts) {
+        break;
+      }
+
+      const delayMs =
+        RETRY_DELAYS_MS[attempt - 1] ??
+        RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1];
+
+      logger.warn(
+        { err, attempt, totalAttempts, delayMs },
+        `Soroban submission failed (attempt ${attempt}/${totalAttempts}), retrying in ${delayMs}ms`,
+      );
+
+      await new Promise<void>((r) => setTimeout(r, delayMs));
+    }
+  }
+
+  const statusCode = extractStatusCode(lastError);
+  throw new SorobanSubmitError(
+    `Soroban transaction submission failed after ${maxRetries} ${maxRetries === 1 ? "retry" : "retries"}: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+    statusCode,
+    10,
+  );
+}


### PR DESCRIPTION
## Summary

This PR addresses four issues across the Stellar Stream backend, improving filtering flexibility, on-chain event completeness, and Soroban RPC resilience.

### #344 — Multi-status filter on `GET /api/streams`
- `?status` now accepts comma-separated values (e.g. `?status=active,paused`)
- Each value is validated; any unknown status returns 400
- AND logic with all existing filters (sender, recipient, asset, etc.)
- Updated Swagger docs and integration tests

### #345 — Date range query params on `GET /api/streams`
- Added `?createdAfter`, `?createdBefore`, `?startAfter`, `?startBefore` (ISO 8601)
- Invalid date strings return 400 with a descriptive error message
- AND logic with existing filters; each param tested in isolation and combined
- Updated Swagger docs and integration tests

### #339 — `StreamTransferred` event in Soroban contract + indexer recipient update
- Confirmed `StreamTransferred { stream_id, old_recipient, new_recipient }` is emitted via `env.events().publish` in `transfer_stream`
- Indexer now also updates the `recipient` column in the SQLite `streams` table on `Transfer` event
- Added snapshot test for the event payload structure
- Existing `transfer_stream` tests still pass

### #353 — Exponential backoff retry for Soroban transaction submission
- Extracted `retryWithBackoff` into `src/utils/sorobanRetry.ts` with full spec compliance
- **3 retry attempts** (4 total calls) with delays of **1s → 2s → 4s**
- Retries only on **503**, **504**, and network errors (ECONNREFUSED, ECONNRESET, timeout, fetch failed)
- **4xx errors are never retried** (client errors are not transient)
- Each retry attempt **logged at `warn` level** with attempt number and delay
- Final failure throws a structured `SorobanSubmitError` with `statusCode` and `retryAfter: 10` fields
- 15 unit tests covering all acceptance criteria (delay timing, error classification, structured error shape)

## Test plan

- [ ] `npx vitest run src/utils/sorobanRetry.test.ts` — all 15 retry unit tests pass
- [ ] `npx vitest run src/services/indexer.test.ts` — existing indexer tests pass
- [ ] `npx vitest run src/integration.test.ts` — integration suite passes
- [ ] `GET /api/streams?status=active,paused` returns streams with either status
- [ ] `GET /api/streams?status=invalid` returns 400
- [ ] `GET /api/streams?createdAfter=2024-01-01T00:00:00Z` filters correctly
- [ ] `GET /api/streams?createdAfter=not-a-date` returns 400
- [ ] Soroban 503 responses trigger retries visible in logs at `warn` level

Closes #339
Closes #344
Closes #345
Closes #353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved retry handling for transient service failures, helping requests recover automatically from temporary network and server issues.
  * Added clearer error details when a request ultimately fails, including guidance on when to try again.

* **Bug Fixes**
  * Reduced unnecessary retries for client-side errors, so invalid requests fail faster.
  * Made retry timing more consistent across failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->