### PR TITLE
feat: add Content-Type enforcement middleware for POST/PATCH routes (…

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,7 @@
 import cors from "cors";
 import helmet from "helmet";
 import { requestLogger } from "./middleware/requestLogger";
+import { requireJsonContentType } from "./middleware/contentType";
 import "dotenv/config";
 import express, { NextFunction, Request, Response } from "express";
 import rateLimit from "express-rate-limit";
@@ -316,6 +317,7 @@ if (ALLOWED_ORIGINS) {
   app.use(cors());
 }
 app.use(requestLogger);
+app.use(requireJsonContentType);
 app.use(
   express.json({
     limit: "32kb",

--- a/backend/src/middleware/contentType.test.ts
+++ b/backend/src/middleware/contentType.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from "vitest";
+import { requireJsonContentType } from "./contentType";
+import type { Request, Response } from "express";
+
+describe("requireJsonContentType", () => {
+  it("calls next for POST with application/json", () => {
+    const req = {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    } as unknown as Request;
+    const res = {} as Response;
+    const next = vi.fn();
+
+    requireJsonContentType(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 415 for POST with missing Content-Type", () => {
+    const req = {
+      method: "POST",
+      headers: {},
+    } as unknown as Request;
+
+    let statusCode = 0;
+    let jsonBody: any;
+    const res = {
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        jsonBody = payload;
+        return this;
+      },
+    } as unknown as Response;
+    const next = vi.fn();
+
+    requireJsonContentType(req, res, next);
+
+    expect(statusCode).toBe(415);
+    expect(jsonBody).toEqual({ error: "Content-Type must be application/json" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 415 for POST with text/plain", () => {
+    const req = {
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+    } as unknown as Request;
+
+    let statusCode = 0;
+    let jsonBody: any;
+    const res = {
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        jsonBody = payload;
+        return this;
+      },
+    } as unknown as Response;
+    const next = vi.fn();
+
+    requireJsonContentType(req, res, next);
+
+    expect(statusCode).toBe(415);
+    expect(jsonBody).toEqual({ error: "Content-Type must be application/json" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 415 for PATCH with wrong Content-Type", () => {
+    const req = {
+      method: "PATCH",
+      headers: { "content-type": "text/html" },
+    } as unknown as Request;
+
+    let statusCode = 0;
+    let jsonBody: any;
+    const res = {
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        jsonBody = payload;
+        return this;
+      },
+    } as unknown as Response;
+    const next = vi.fn();
+
+    requireJsonContentType(req, res, next);
+
+    expect(statusCode).toBe(415);
+    expect(jsonBody).toEqual({ error: "Content-Type must be application/json" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next for GET with no Content-Type", () => {
+    const req = {
+      method: "GET",
+      headers: {},
+    } as unknown as Request;
+    const res = {} as Response;
+    const next = vi.fn();
+
+    requireJsonContentType(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls next for non-POST/PATCH methods", () => {
+    const req = {
+      method: "DELETE",
+      headers: {},
+    } as unknown as Request;
+    const res = {} as Response;
+    const next = vi.fn();
+
+    requireJsonContentType(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/middleware/contentType.ts
+++ b/backend/src/middleware/contentType.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from "express";
+
+export function requireJsonContentType(req: Request, res: Response, next: NextFunction) {
+  if (req.method === "POST" || req.method === "PATCH") {
+    const contentType = req.headers["content-type"];
+    if (!contentType || !contentType.startsWith("application/json")) {
+      res.status(415).json({ error: "Content-Type must be application/json" });
+      return;
+    }
+  }
+  next();
+}


### PR DESCRIPTION
# Closes #367

## Summary

This PR adds a global Express middleware that enforces `Content-Type: 
application/json` on all POST and PATCH requests. Previously, clients 
could send requests with any `Content-Type` header (e.g. `text/plain`) 
and bypass validation depending on middleware order. This fix ensures 
a consistent and predictable API contract.

---

## Changes Made

### New File: `backend/src/middleware/contentType.ts`
- Created a middleware function `requireJsonContentType` that intercepts 
  all incoming requests
- Returns HTTP `415 Unsupported Media Type` with a JSON error body when 
  a POST or PATCH request is missing or has an incorrect `Content-Type` 
  header
- GET, PUT, DELETE and all other methods are completely unaffected and 
  pass through normally

### Modified File: `backend/src/index.ts`
- Registered `requireJsonContentType` middleware globally before all 
  route handlers so it applies to every POST and PATCH route in the 
  application

### New File: `backend/src/middleware/contentType.test.ts`
- Added 6 integration tests covering all acceptance criteria cases

---

## Test Coverage

| # | Test Case | Result |
|---|-----------|--------|
| 1 | POST with correct `Content-Type: application/json` | ✅ Passes through |
| 2 | POST with missing `Content-Type` | ✅ Returns 415 |
| 3 | POST with wrong `Content-Type: text/plain` | ✅ Returns 415 |
| 4 | PATCH with wrong `Content-Type` | ✅ Returns 415 |
| 5 | GET with no `Content-Type` | ✅ Unaffected |
| 6 | DELETE (non-POST/PATCH) | ✅ Unaffected |

**6/6 tests passing. Zero new TypeScript errors introduced.**

---

## Error Response Format

When an invalid `Content-Type` is detected, the middleware returns:

```json
{
  "error": "Content-Type must be application/json"
}
```
HTTP Status: `415 Unsupported Media Type`

---

## What Was NOT Changed
- No existing route files were modified
- No existing middleware was changed
- No dependencies were added
- `package-lock.json` was not committed (repo uses `yarn.lock`)

---

## How to Test Locally

```bash
# Wrong Content-Type — should return 415
curl -X POST http://localhost:3000/api/streams \
  -H "Content-Type: text/plain" \
  -d '{"name":"test"}'

# Correct Content-Type — should pass through
curl -X POST http://localhost:3000/api/streams \
  -H "Content-Type: application/json" \
  -d '{"name":"test"}'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests that create or update data now require a JSON `Content-Type` header earlier, returning a clear `415` error when it’s missing or incorrect.
  * Non-write requests like `GET` and `DELETE` continue to work without needing a JSON `Content-Type` header.

* **Tests**
  * Added coverage for valid JSON requests, invalid content types, and methods that should bypass the check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->