### PR TITLE
Add Dependabot configuration for npm and Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    assignees:
+      - "ritik4ever"
+    labels:
+      - "dependencies"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    assignees:
+      - "ritik4ever"
+    labels:
+      - "dependencies"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "cargo"
+    directory: "/contracts"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    assignees:
+      - "ritik4ever"
+    labels:
+      - "dependencies"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR adds a .github/dependabot.yml configuration to enable weekly dependency updates for the repository.

- Adds npm dependency update schedules for backend/ and frontend/
- Adds Cargo dependency update schedule for contracts/
- Groups all updates into one PR per ecosystem
- Auto-assigns PRs to maintainer ritik4ever

Closes #416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency update checks on a weekly schedule.
  * Enabled updates for backend, frontend, and contracts dependencies.
  * Limited the number of open update pull requests and grouped dependency updates for easier review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->