### PR TITLE
Add RecipientDashboard claim button with Freighter signing

### DIFF
--- a/frontend/src/components/RecipientDashboard.test.tsx
+++ b/frontend/src/components/RecipientDashboard.test.tsx
@@ -22,9 +22,6 @@ import { RecipientDashboard } from "./RecipientDashboard";
 // Mock soroban service so tests don't hit the network
 // ---------------------------------------------------------------------------
 
-vi.mock("../services/soroban", () => ({
-  claimStream: vi.fn(),
-}));
 vi.mock("../services/soroban", () => {
   const mockFn = vi.fn();
   return {
@@ -135,7 +132,7 @@ describe("RecipientDashboard", () => {
     expect(screen.getByText("active")).toBeInTheDocument();
   });
 
-  it("calls claim API with correct stream ID and amount when claim button is clicked", async () => {
+  it("submits claim with correct stream ID, recipient, amount, and asset when claim button is clicked", async () => {
     setupRecipientHandler([activeStream]);
     render(<RecipientDashboard recipientAddress={RECIPIENT} />);
 
@@ -147,7 +144,8 @@ describe("RecipientDashboard", () => {
       fireEvent.click(screen.getByLabelText(/claim 500 USDC from stream 1/i));
     });
 
-    expect(mockClaimOnChain).toHaveBeenCalledWith("1", RECIPIENT, 500);
+    expect(mockClaimStream).toHaveBeenCalledWith("1", RECIPIENT, 500, "USDC");
+    expect(mockClaimOnChain).toHaveBeenCalledWith("1", RECIPIENT, 500, "USDC");
   });
 
   it("claim button is disabled when vested amount is 0", async () => {
@@ -207,8 +205,14 @@ describe("RecipientDashboard", () => {
 
     await waitFor(() => {
       const toast = screen.getByRole("status");
-      expect(toast).toHaveTextContent(/successfully claimed 500 tokens from stream 1/i);
+      expect(toast).toHaveTextContent(/successfully claimed 500 USDC from stream 1/i);
+      expect(toast).toHaveTextContent(/transaction hash: txhash123/i);
     }, { timeout: 3000 });
+    expect(screen.getByRole("link", { name: /view on stellar expert/i }))
+      .toHaveAttribute(
+        "href",
+        "https://stellar.expert/explorer/testnet/tx/txhash123",
+      );
   });
 
   it("shows error toast when claim fails", async () => {
@@ -280,10 +284,10 @@ describe("RecipientDashboard", () => {
     });
 
     await waitFor(() =>
-      expect(screen.getByText(/successfully claimed 500 tokens from stream 1/i)).toBeInTheDocument(),
+      expect(screen.getByText(/successfully claimed 500 USDC from stream 1/i)).toBeInTheDocument(),
     );
 
     fireEvent.click(screen.getByLabelText("Dismiss notification"));
-    expect(screen.queryByText(/successfully claimed 500 tokens from stream 1/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/successfully claimed 500 USDC from stream 1/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/RecipientDashboard.tsx
+++ b/frontend/src/components/RecipientDashboard.tsx
@@ -19,10 +19,12 @@ interface RecipientDashboardProps {
 interface ToastProps {
   message: string;
   type: "success" | "error";
+  actionHref?: string;
+  actionLabel?: string;
   onDismiss: () => void;
 }
 
-function Toast({ message, type, onDismiss }: ToastProps) {
+function Toast({ message, type, actionHref, actionLabel, onDismiss }: ToastProps) {
   return (
     <div
       className={`claim-toast claim-toast--${type}`}
@@ -33,6 +35,16 @@ function Toast({ message, type, onDismiss }: ToastProps) {
         {type === "success" ? "✓" : "✕"}
       </span>
       <span className="claim-toast__msg">{message}</span>
+      {actionHref && actionLabel && (
+        <a
+          className="claim-toast__link"
+          href={actionHref}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {actionLabel}
+        </a>
+      )}
       <button
         type="button"
         className="claim-toast__dismiss"
@@ -54,6 +66,7 @@ interface ClaimButtonProps {
   claimableAmount: number;
   assetCode: string;
   claimState: ClaimState;
+  walletConnected: boolean;
   onClaim: () => void;
 }
 
@@ -62,15 +75,17 @@ function ClaimButton({
   claimableAmount,
   assetCode,
   claimState,
+  walletConnected,
   onClaim,
 }: ClaimButtonProps) {
   const isThisStream = claimState.streamId === streamId;
   const isPending = isThisStream && claimState.status === "pending";
   const isConfirmed = isThisStream && claimState.status === "confirmed";
   const isFailed = isThisStream && claimState.status === "failed";
-  const disabled = isPending || claimableAmount <= 0;
+  const disabled = !walletConnected || isPending || claimableAmount <= 0;
 
   let label = `Claim ${claimableAmount} ${assetCode}`;
+  if (!walletConnected) label = "Connect wallet";
   if (isPending) label = "Claiming…";
   if (isConfirmed) label = "Claimed ✓";
 
@@ -106,6 +121,10 @@ function statusClass(status: Stream["progress"]["status"]): string {
   return map[status] ?? "badge";
 }
 
+function getStellarExpertTxUrl(txHash: string): string {
+  return `https://stellar.expert/explorer/testnet/tx/${txHash}`;
+}
+
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
@@ -114,7 +133,12 @@ export function RecipientDashboard({ recipientAddress }: RecipientDashboardProps
   const [streams, setStreams] = useState<Stream[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+    actionHref?: string;
+    actionLabel?: string;
+  } | null>(null);
   const [batchModalOpen, setBatchModalOpen] = useState(false);
   const [pendingBatchInputs, setPendingBatchInputs] = useState<BatchClaimInput[]>([]);
 
@@ -146,8 +170,10 @@ export function RecipientDashboard({ recipientAddress }: RecipientDashboardProps
     async (streamId: string, result: ClaimResult, _history: StreamEvent[]) => {
       await refreshStreams();
       setToast({
-        message: `Successfully claimed ${result.claimedAmount} tokens from stream ${streamId}.`,
+        message: `Successfully claimed ${result.claimedAmount} ${result.assetCode} from stream ${streamId}. Transaction hash: ${result.txHash}`,
         type: "success",
+        actionHref: getStellarExpertTxUrl(result.txHash),
+        actionLabel: "View on Stellar Expert",
       });
     },
     [refreshStreams],
@@ -157,8 +183,10 @@ export function RecipientDashboard({ recipientAddress }: RecipientDashboardProps
     async (streamId: string, result: ClaimResult, _history: StreamEvent[]) => {
       await refreshStreams();
       setToast({
-        message: `Successfully claimed ${result.claimedAmount} from stream ${streamId}.`,
+        message: `Successfully claimed ${result.claimedAmount} ${result.assetCode} from stream ${streamId}. Transaction hash: ${result.txHash}`,
         type: "success",
+        actionHref: getStellarExpertTxUrl(result.txHash),
+        actionLabel: "View on Stellar Expert",
       });
     },
     [refreshStreams],
@@ -296,6 +324,8 @@ export function RecipientDashboard({ recipientAddress }: RecipientDashboardProps
         <Toast
           message={toast.message}
           type={toast.type}
+          actionHref={toast.actionHref}
+          actionLabel={toast.actionLabel}
           onDismiss={() => setToast(null)}
         />
       )}
@@ -442,11 +472,13 @@ export function RecipientDashboard({ recipientAddress }: RecipientDashboardProps
                           claimableAmount={stream.progress.vestedAmount}
                           assetCode={stream.assetCode}
                           claimState={claimState}
+                          walletConnected={Boolean(recipientAddress)}
                           onClaim={() =>
                             claim({
                               streamId: stream.id,
                               recipientAddress: recipientAddress,
                               amount: stream.progress.vestedAmount,
+                              assetCode: stream.assetCode,
                             })
                           }
                         />

--- a/frontend/src/hooks/useClaimBatch.ts
+++ b/frontend/src/hooks/useClaimBatch.ts
@@ -122,7 +122,7 @@ export function useClaimBatch(
       for (let i = 0; i < claimable.length; i++) {
         if (runIdRef.current !== runId) return;
 
-        const { streamId, amount } = claimable[i];
+        const { streamId, amount, assetCode } = claimable[i];
         setState((s) => ({
           ...s,
           progress: { current: i + 1, total: claimable.length },
@@ -133,6 +133,7 @@ export function useClaimBatch(
             streamId,
             recipientAddress,
             amount,
+            assetCode,
           );
           successCount++;
           await onSuccess(streamId, result, history);

--- a/frontend/src/hooks/useClaimStream.test.ts
+++ b/frontend/src/hooks/useClaimStream.test.ts
@@ -420,8 +420,8 @@ describe("useClaimStream", () => {
       });
 
       expect(mockClaimStream).toHaveBeenCalledTimes(2);
-      expect(mockClaimStream).toHaveBeenNthCalledWith(1, "1", "GTEST123456789", 100);
-      expect(mockClaimStream).toHaveBeenNthCalledWith(2, "2", "GTEST123456789", 50);
+      expect(mockClaimStream).toHaveBeenNthCalledWith(1, "1", "GTEST123456789", 100, "XLM");
+      expect(mockClaimStream).toHaveBeenNthCalledWith(2, "2", "GTEST123456789", 50, "XLM");
       expect(onSuccess).toHaveBeenCalledTimes(2);
       expect(result.current.state.phase).toBe("complete");
       expect(result.current.state.successCount).toBe(2);

--- a/frontend/src/hooks/useClaimStream.ts
+++ b/frontend/src/hooks/useClaimStream.ts
@@ -19,6 +19,8 @@ export interface ClaimInput {
   recipientAddress: string;
   /** Claimable amount shown in the UI (informational; contract enforces the real amount). */
   amount: number;
+  /** Asset label shown after the direct Soroban claim is submitted. */
+  assetCode?: string;
 }
 
 // ── Hook ───────────────────────────────────────────────────────────────────
@@ -52,7 +54,7 @@ export function useClaimStream(
   const claimIdRef = useRef(0);
 
   const claim = useCallback(
-    async ({ streamId, recipientAddress, amount }: ClaimInput) => {
+    async ({ streamId, recipientAddress, amount, assetCode }: ClaimInput) => {
       // Block concurrent claims
       if (claimState.status === "pending") return;
 
@@ -64,11 +66,9 @@ export function useClaimStream(
       setClaimState({ streamId, status: "pending", error: null });
 
       try {
-        const { result, history } = await claimStream(
-          streamId,
-          recipientAddress,
-          amount,
-        );
+        const { result, history } = assetCode
+          ? await claimStream(streamId, recipientAddress, amount, assetCode)
+          : await claimStream(streamId, recipientAddress, amount);
 
         // Guard against stale callbacks from superseded claims
         if (claimIdRef.current !== claimId) return;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -874,6 +874,97 @@ td {
   font-size: 0.9rem;
 }
 
+.claim-toast {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  padding: 0.65rem 0.8rem;
+  border: 1px solid #bbf7d0;
+  border-radius: 8px;
+  background: #f0fdf4;
+  color: #166534;
+  font-size: 0.9rem;
+}
+
+.claim-toast--error {
+  border-color: #fecaca;
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.claim-toast__icon {
+  font-weight: 700;
+}
+
+.claim-toast__msg {
+  flex: 1;
+}
+
+.claim-toast__link {
+  color: inherit;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.claim-toast__dismiss {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.btn-claim {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  min-width: 112px;
+  min-height: 36px;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid #0f766e;
+  border-radius: 6px;
+  background: #0f766e;
+  color: #ffffff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.btn-claim:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.btn-claim--confirmed {
+  border-color: #15803d;
+  background: #15803d;
+}
+
+.btn-claim--failed {
+  border-color: #dc2626;
+  background: #dc2626;
+}
+
+.btn-claim__spinner {
+  width: 0.85rem;
+  height: 0.85rem;
+  border: 2px solid rgba(255, 255, 255, 0.55);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: recipient-spin 0.7s linear infinite;
+}
+
+.claim-pending-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #0f766e;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
 .loading-spinner {
   width: 32px;
   height: 32px;

--- a/frontend/src/services/soroban.test.ts
+++ b/frontend/src/services/soroban.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getAccount = vi.fn();
+const prepareTransaction = vi.fn();
+const sendTransaction = vi.fn();
+const getTransaction = vi.fn();
+const signTransaction = vi.fn();
+const contractCall = vi.fn();
+const addOperation = vi.fn();
+const fromXDR = vi.fn();
+
+const fakePreparedTransaction = {
+  toXDR: vi.fn(() => "prepared-claim-xdr"),
+};
+const fakeSignedTransaction = { kind: "signed-tx" };
+
+vi.mock("@stellar/freighter-api", () => ({
+  signTransaction,
+}));
+
+vi.mock("@stellar/stellar-sdk", () => {
+  class MockServer {
+    getAccount = getAccount;
+    prepareTransaction = prepareTransaction;
+    sendTransaction = sendTransaction;
+    getTransaction = getTransaction;
+  }
+
+  class MockContract {
+    constructor(public contractId: string) {}
+
+    call(method: string, ...args: unknown[]) {
+      contractCall(method, ...args);
+      return { method, args };
+    }
+  }
+
+  class MockAddress {
+    constructor(private value: string) {}
+
+    toScVal() {
+      return { address: this.value };
+    }
+  }
+
+  class MockTransactionBuilder {
+    static fromXDR(xdr: string, networkPassphrase: string) {
+      fromXDR(xdr, networkPassphrase);
+      return fakeSignedTransaction;
+    }
+
+    constructor(
+      public sourceAccount: unknown,
+      public options: Record<string, unknown>,
+    ) {}
+
+    addOperation(operation: unknown) {
+      addOperation(operation);
+      return this;
+    }
+
+    setTimeout() {
+      return this;
+    }
+
+    build() {
+      return { kind: "claim-tx" };
+    }
+  }
+
+  return {
+    Address: MockAddress,
+    Contract: MockContract,
+    Networks: {
+      TESTNET: "Test SDF Network ; September 2015",
+    },
+    TransactionBuilder: MockTransactionBuilder,
+    nativeToScVal: vi.fn((value: unknown, options: unknown) => ({
+      value,
+      options,
+    })),
+    rpc: {
+      Server: MockServer,
+    },
+  };
+});
+
+describe("claimStream", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv(
+      "VITE_CONTRACT_ID",
+      "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
+    );
+    vi.stubEnv("VITE_RPC_URL", "https://soroban-testnet.stellar.org:443");
+    vi.stubEnv(
+      "VITE_NETWORK_PASSPHRASE",
+      "Test SDF Network ; September 2015",
+    );
+
+    getAccount.mockResolvedValue({ accountId: "GRECIPIENT" });
+    prepareTransaction.mockResolvedValue(fakePreparedTransaction);
+    sendTransaction.mockResolvedValue({ status: "PENDING", hash: "txhash123" });
+    getTransaction.mockResolvedValue({ status: "SUCCESS" });
+    signTransaction.mockResolvedValue("signed-claim-xdr");
+
+    contractCall.mockClear();
+    addOperation.mockClear();
+    fromXDR.mockClear();
+    fakePreparedTransaction.toXDR.mockClear();
+  });
+
+  it("builds a claim transaction, signs with Freighter, and submits it", async () => {
+    const { claimStream } = await import("./soroban");
+
+    const response = await claimStream("1", "GRECIPIENT", 500, "USDC");
+
+    expect(contractCall).toHaveBeenCalledWith(
+      "claim",
+      { value: 1, options: { type: "u64" } },
+      { address: "GRECIPIENT" },
+      { value: 500n, options: { type: "i128" } },
+    );
+    expect(fakePreparedTransaction.toXDR).toHaveBeenCalled();
+    expect(signTransaction).toHaveBeenCalledWith("prepared-claim-xdr", {
+      accountToSign: "GRECIPIENT",
+      networkPassphrase: "Test SDF Network ; September 2015",
+    });
+    expect(fromXDR).toHaveBeenCalledWith(
+      "signed-claim-xdr",
+      "Test SDF Network ; September 2015",
+    );
+    expect(sendTransaction).toHaveBeenCalledWith(fakeSignedTransaction);
+    expect(response.result).toEqual({
+      claimedAmount: 500,
+      assetCode: "USDC",
+      txHash: "txhash123",
+    });
+  });
+});

--- a/frontend/src/services/soroban.ts
+++ b/frontend/src/services/soroban.ts
@@ -4,15 +4,22 @@
  * For detailed TypeScript usage examples of the generated contract client,
  * see: docs/CONTRACT_BINDINGS.md
  *
- * `claimStream` calls the backend `/api/streams/:id/claim` endpoint which
- * builds, signs (fee-sponsored), and submits the Soroban `claim` transaction
- * on behalf of the recipient.  The backend returns the claimed amount and the
- * updated event history.
+ * `claimStream` builds a Soroban `claim` transaction in the browser, asks
+ * Freighter to sign as the recipient, and submits the signed transaction to
+ * Stellar RPC.
  *
  * To use the generated contract client directly (for read operations or
  * wallet-signed transactions), import from `./contractClient`.
  */
 
+import * as freighter from "@stellar/freighter-api";
+import {
+  Address,
+  Contract,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc,
+} from "@stellar/stellar-sdk";
 import { getAuthToken } from "./api";
 import type { StreamEvent } from "./api";
 import { CONTRACT_ID, RPC_URL, NETWORK_PASSPHRASE } from "./contractClient";
@@ -42,6 +49,86 @@ export class SorobanClaimError extends Error {
   }
 }
 
+const DEFAULT_FEE_STROOPS = "100";
+const TX_POLL_INTERVAL_MS = 1_000;
+const TX_POLL_ATTEMPTS = 30;
+
+type FreighterSignedTransaction =
+  | string
+  | {
+      signedTxXdr?: string;
+      signedTransaction?: string;
+      transactionXdr?: string;
+    };
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizeSignedXdr(signed: FreighterSignedTransaction): string {
+  if (typeof signed === "string") return signed;
+
+  const xdr =
+    signed.signedTxXdr ?? signed.signedTransaction ?? signed.transactionXdr;
+  if (!xdr) {
+    throw new SorobanClaimError(
+      "Freighter did not return a signed transaction.",
+      "FREIGHTER_SIGNING_FAILED",
+    );
+  }
+  return xdr;
+}
+
+function toContractI128Amount(amount: number): bigint {
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new SorobanClaimError(
+      "No claimable amount available.",
+      "NO_CLAIMABLE_AMOUNT",
+    );
+  }
+
+  if (!Number.isInteger(amount)) {
+    throw new SorobanClaimError(
+      "Claim amount must be an integer contract amount.",
+      "INVALID_CLAIM_AMOUNT",
+    );
+  }
+
+  return BigInt(amount);
+}
+
+function getRpcServer(): rpc.Server {
+  return new rpc.Server(RPC_URL, {
+    allowHttp: RPC_URL.startsWith("http://"),
+  });
+}
+
+async function waitForFinalTransactionStatus(
+  server: rpc.Server,
+  txHash: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < TX_POLL_ATTEMPTS; attempt++) {
+    let status: string;
+    try {
+      const tx = await server.getTransaction(txHash);
+      status = String((tx as { status?: unknown }).status ?? "");
+    } catch {
+      status = "NOT_FOUND";
+    }
+
+    if (status === "SUCCESS") return;
+
+    if (status === "FAILED") {
+      throw new SorobanClaimError(
+        "Soroban claim transaction failed.",
+        "TRANSACTION_FAILED",
+      );
+    }
+
+    await sleep(TX_POLL_INTERVAL_MS);
+  }
+}
+
 /**
  * Claim vested tokens from a stream.
  *
@@ -49,40 +136,90 @@ export class SorobanClaimError extends Error {
  * @param recipientAddress - Stellar public key of the recipient (must match stream).
  * @param amount         - Claimable amount as reported by the backend (for display only;
  *                         the contract determines the actual claimable amount on-chain).
+ * @param assetCode      - Asset code used in the UI result.
  */
-export async function claimOnChain(
+export async function claimWithFreighter(
   streamId: string,
   recipientAddress: string,
   amount: number,
+  assetCode = "tokens",
 ): Promise<ClaimResponse> {
-  const token = getAuthToken();
-
-  const response = await fetch(`${API_BASE}/streams/${streamId}/claim`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-    body: JSON.stringify({ recipientAddress, amount }),
-  });
-
-  if (!response.ok) {
-    let message = `Claim failed (${response.status})`;
-    let code = "UNKNOWN";
-    try {
-      const body = (await response.json()) as { error?: string; code?: string };
-      if (body.error) message = body.error;
-      if (body.code) code = body.code;
-    } catch {
-      // ignore JSON parse errors
-    }
-    throw new SorobanClaimError(message, code);
+  if (!CONTRACT_ID) {
+    throw new SorobanClaimError(
+      "Missing VITE_CONTRACT_ID; cannot submit Soroban claim.",
+      "MISSING_CONTRACT_ID",
+    );
   }
 
-  return response.json() as Promise<ClaimResponse>;
+  const streamIdNumber = Number(streamId);
+  if (!Number.isSafeInteger(streamIdNumber) || streamIdNumber <= 0) {
+    throw new SorobanClaimError("Invalid stream ID.", "INVALID_STREAM_ID");
+  }
+
+  const contractAmount = toContractI128Amount(amount);
+  const server = getRpcServer();
+  const sourceAccount = await server.getAccount(recipientAddress);
+  const contract = new Contract(CONTRACT_ID);
+
+  const transaction = new TransactionBuilder(sourceAccount, {
+    fee: DEFAULT_FEE_STROOPS,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      contract.call(
+        "claim",
+        nativeToScVal(streamIdNumber, { type: "u64" }),
+        new Address(recipientAddress).toScVal(),
+        nativeToScVal(contractAmount, { type: "i128" }),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const preparedTransaction = await server.prepareTransaction(transaction);
+  const signed = await (freighter as any).signTransaction(
+    preparedTransaction.toXDR(),
+    {
+      accountToSign: recipientAddress,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    },
+  );
+  const signedTransaction = TransactionBuilder.fromXDR(
+    normalizeSignedXdr(signed),
+    NETWORK_PASSPHRASE,
+  );
+
+  const sendResponse = await server.sendTransaction(signedTransaction);
+  const txHash = (sendResponse as { hash?: string }).hash;
+  if (!txHash) {
+    throw new SorobanClaimError(
+      "Soroban RPC did not return a transaction hash.",
+      "MISSING_TRANSACTION_HASH",
+    );
+  }
+
+  const sendStatus = String((sendResponse as { status?: unknown }).status ?? "");
+  if (sendStatus && sendStatus !== "PENDING") {
+    throw new SorobanClaimError(
+      `Soroban claim submission failed: ${sendStatus}`,
+      "TRANSACTION_SUBMISSION_FAILED",
+    );
+  }
+
+  await waitForFinalTransactionStatus(server, txHash);
+
+  return {
+    result: {
+      claimedAmount: amount,
+      assetCode,
+      txHash,
+    },
+    history: [],
+  };
 }
 
-export const claimStream = claimOnChain;
+export const claimOnChain = claimWithFreighter;
+export const claimStream = claimWithFreighter;
 
 export interface ClaimableBatchResponse {
   amounts: Record<string, number>;
@@ -120,4 +257,3 @@ export async function getClaimableBatch(
 
   return response.json() as Promise<ClaimableBatchResponse>;
 }
-


### PR DESCRIPTION
Closes #391 

- Wire `RecipientDashboard` claim actions to submit Freighter-signed Soroban
  `claim(stream_id, recipient, amount)` transactions directly.
  - Disable claim action unless a wallet address is connected and preserve the
  displayed claimable amount before signing.
  - Show the returned transaction hash with a Stellar Expert testnet link after
  successful claims.
  - Add focused Vitest coverage for Freighter signing and transaction submission.

  ## Details

  The previous claim path called the backend claim API. This updates `claimStream`
  to:

  1. Build a Soroban contract call for `claim`.
  2. Prepare the transaction through Stellar RPC.
  3. Request a Freighter signature for the recipient account.
  4. Submit the signed transaction to RPC.
  5. Poll for transaction success and return the hash to the UI.

  Single and batch claim hooks now pass the stream asset code through the claim
  result so the success UI remains accurate.

  ## Testing

  - `npm test -- --run src/services/soroban.test.ts src/hooks/useClaimStream.test.ts
  src/components/RecipientDashboard.test.tsx`
  - `npx eslint ...` on changed files
  - Targeted `tsc --noEmit` on changed service/component/hooks

  ## Notes

  Full `npm run build` is currently blocked by an unrelated existing syntax error in
  `frontend/src/components/SenderDashboard.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claiming now happens directly in the app through wallet signing, with support for asset-specific claims.
  * Success messages now show the claimed asset, transaction hash, and a link to view the transaction on Stellar Expert.
  * Claim buttons now prompt users to connect a wallet when needed.

* **Bug Fixes**
  * Updated batch and single-claim flows to handle asset codes correctly.
  * Improved claim success and error handling for more accurate notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->