### PR TITLE
feat(384): add bulk cancel/pause UI with toolbar buttons and confirmation modal

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1395,6 +1395,109 @@ app.post(
   },
 );
 
+const bulkActionBodySchema = z.object({
+  streamIds: z
+    .array(z.string().min(1, "Stream ID must not be empty"))
+    .min(1, "At least one stream ID is required")
+    .max(50, "Maximum 50 stream IDs per request"),
+});
+
+// POST /api/streams/bulk-cancel — cancel multiple streams at once
+app.post(
+  "/api/streams/bulk-cancel",
+  mutationLimiter,
+  authMiddleware,
+  async (req: Request, res: Response) => {
+    const parsed = bulkActionBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendValidationError(req, res, parsed.error.issues);
+      return;
+    }
+
+    const user = (req as any).user;
+    const results: Array<{ streamId: string; success: boolean; error?: string }> = [];
+
+    for (const streamId of parsed.data.streamIds) {
+      const parsedId = parseStreamId(streamId);
+      if (!parsedId.ok) {
+        results.push({ streamId, success: false, error: "Invalid stream ID" });
+        continue;
+      }
+
+      const stream = getStream(parsedId.value);
+      if (!stream) {
+        results.push({ streamId, success: false, error: "Stream not found" });
+        continue;
+      }
+
+      if (stream.sender !== user.accountId) {
+        results.push({ streamId, success: false, error: "Forbidden: not the sender" });
+        continue;
+      }
+
+      try {
+        const updated = await cancelStream(parsedId.value);
+        if (!updated) {
+          results.push({ streamId, success: false, error: "Failed to cancel stream" });
+        } else {
+          results.push({ streamId, success: true });
+        }
+      } catch (error: any) {
+        logger.error({ err: error, streamId }, "failed to cancel stream in bulk");
+        results.push({ streamId, success: false, error: error.message || "Failed to cancel stream" });
+      }
+    }
+
+    res.json({ results });
+  },
+);
+
+// POST /api/streams/bulk-pause — pause multiple streams at once
+app.post(
+  "/api/streams/bulk-pause",
+  mutationLimiter,
+  authMiddleware,
+  async (req: Request, res: Response) => {
+    const parsed = bulkActionBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendValidationError(req, res, parsed.error.issues);
+      return;
+    }
+
+    const user = (req as any).user;
+    const results: Array<{ streamId: string; success: boolean; error?: string }> = [];
+
+    for (const streamId of parsed.data.streamIds) {
+      const parsedId = parseStreamId(streamId);
+      if (!parsedId.ok) {
+        results.push({ streamId, success: false, error: "Invalid stream ID" });
+        continue;
+      }
+
+      const stream = getStream(parsedId.value);
+      if (!stream) {
+        results.push({ streamId, success: false, error: "Stream not found" });
+        continue;
+      }
+
+      if (stream.sender !== user.accountId) {
+        results.push({ streamId, success: false, error: "Forbidden: not the sender" });
+        continue;
+      }
+
+      try {
+        await pauseStream(parsedId.value);
+        results.push({ streamId, success: true });
+      } catch (error: any) {
+        logger.error({ err: error, streamId }, "failed to pause stream in bulk");
+        results.push({ streamId, success: false, error: error.message || "Failed to pause stream" });
+      }
+    }
+
+    res.json({ results });
+  },
+);
+
 // POST /api/streams/:id/reconcile — sync on-chain state to local SQLite
 app.post(
   "/api/streams/:id/reconcile",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,8 @@ import { useWebSocket } from "./hooks/useWebSocket";
 import { useUrlFilters } from "./hooks/useUrlFilters";
 import {
   ApiError,
+  bulkCancelStreams,
+  bulkPauseStreams,
   cancelStream,
   createStream,
   getWebSocketUrl,
@@ -268,6 +270,44 @@ function App() {
     }
   }
 
+  async function handleBulkCancel(streamIds: string[]): Promise<void> {
+    try {
+      const results = await bulkCancelStreams(streamIds);
+      const failures = results.filter((r) => !r.success);
+      if (failures.length > 0) {
+        showToast(
+          `Canceled ${results.length - failures.length}/${results.length}. Failures: ${failures.map((f) => `${f.streamId}: ${f.error}`).join("; ")}`,
+          "error",
+        );
+      } else {
+        showToast(`Canceled ${results.length} stream${results.length !== 1 ? "s" : ""}`, "info");
+      }
+      await refreshStreams(apiFilters);
+      void refreshUnfilteredCount();
+    } catch (err) {
+      showToast("Bulk cancel failed", "error");
+    }
+  }
+
+  async function handleBulkPause(streamIds: string[]): Promise<void> {
+    try {
+      const results = await bulkPauseStreams(streamIds);
+      const failures = results.filter((r) => !r.success);
+      if (failures.length > 0) {
+        showToast(
+          `Paused ${results.length - failures.length}/${results.length}. Failures: ${failures.map((f) => `${f.streamId}: ${f.error}`).join("; ")}`,
+          "error",
+        );
+      } else {
+        showToast(`Paused ${results.length} stream${results.length !== 1 ? "s" : ""}`, "info");
+      }
+      await refreshStreams(apiFilters);
+      void refreshUnfilteredCount();
+    } catch (err) {
+      showToast("Bulk pause failed", "error");
+    }
+  }
+
   async function handleUpdateStartTime(streamId: string, nextStartAt: number) {
     try {
       await updateStreamStartAt(streamId, nextStartAt);
@@ -394,6 +434,8 @@ function App() {
               onCancel={handleCancel}
               onPause={handlePause}
               onResume={handleResume}
+              onBulkCancel={handleBulkCancel}
+              onBulkPause={handleBulkPause}
               onEditStartTime={(stream, triggerRef) =>
                 setEditingStream({ stream, triggerRef })
               }

--- a/frontend/src/components/StreamsTable.test.tsx
+++ b/frontend/src/components/StreamsTable.test.tsx
@@ -171,12 +171,20 @@ describe("StreamsTable infinite scroll", () => {
     const onLoadMore = vi.fn();
     let observerCallback: IntersectionObserverCallback = () => {};
 
-    vi.spyOn(window, "IntersectionObserver").mockImplementation(
-      (callback) => {
-        observerCallback = callback;
-        return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn(), root: null, rootMargin: "", thresholds: [] };
-      },
-    );
+    function MockIntersectionObserver(
+      this: IntersectionObserver,
+      callback: IntersectionObserverCallback,
+    ) {
+      observerCallback = callback;
+      this.observe = vi.fn();
+      this.disconnect = vi.fn();
+      this.unobserve = vi.fn();
+      this.root = null;
+      this.rootMargin = "";
+      this.thresholds = [];
+    }
+
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
 
     render(
       <StreamsTable
@@ -187,23 +195,32 @@ describe("StreamsTable infinite scroll", () => {
       />,
     );
 
-    // Simulate sentinel becoming visible
     const sentinel = screen.getByTestId("infinite-scroll-sentinel");
     observerCallback([{ isIntersecting: true, target: sentinel } as unknown as IntersectionObserverEntry], null!);
 
     expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
   });
 
   it("does not call onLoadMore when hasMore is false", () => {
     const onLoadMore = vi.fn();
     let observerCallback: IntersectionObserverCallback = () => {};
 
-    vi.spyOn(window, "IntersectionObserver").mockImplementation(
-      (callback) => {
-        observerCallback = callback;
-        return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn(), root: null, rootMargin: "", thresholds: [] };
-      },
-    );
+    function MockIntersectionObserver(
+      this: IntersectionObserver,
+      callback: IntersectionObserverCallback,
+    ) {
+      observerCallback = callback;
+      this.observe = vi.fn();
+      this.disconnect = vi.fn();
+      this.unobserve = vi.fn();
+      this.root = null;
+      this.rootMargin = "";
+      this.thresholds = [];
+    }
+
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
 
     render(
       <StreamsTable
@@ -218,18 +235,28 @@ describe("StreamsTable infinite scroll", () => {
     observerCallback([{ isIntersecting: true, target: sentinel } as unknown as IntersectionObserverEntry], null!);
 
     expect(onLoadMore).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
   });
 
   it("does not call onLoadMore when already loadingMore", () => {
     const onLoadMore = vi.fn();
     let observerCallback: IntersectionObserverCallback = () => {};
 
-    vi.spyOn(window, "IntersectionObserver").mockImplementation(
-      (callback) => {
-        observerCallback = callback;
-        return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn(), root: null, rootMargin: "", thresholds: [] };
-      },
-    );
+    function MockIntersectionObserver(
+      this: IntersectionObserver,
+      callback: IntersectionObserverCallback,
+    ) {
+      observerCallback = callback;
+      this.observe = vi.fn();
+      this.disconnect = vi.fn();
+      this.unobserve = vi.fn();
+      this.root = null;
+      this.rootMargin = "";
+      this.thresholds = [];
+    }
+
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
 
     render(
       <StreamsTable
@@ -244,6 +271,8 @@ describe("StreamsTable infinite scroll", () => {
     observerCallback([{ isIntersecting: true, target: sentinel } as unknown as IntersectionObserverEntry], null!);
 
     expect(onLoadMore).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
   });
 });
 
@@ -281,5 +310,86 @@ describe("StreamsTable WebSocket progress updates", () => {
     // 2. Simulating a stream_progress message with { streamId: "1", progress: { percentComplete: 50 } }
     // 3. Asserting the progress bar for stream 1 updates to "50%"
     // The component structure is in place to handle this via streamProgressUpdates Map
+  });
+});
+
+describe("StreamsTable bulk selection UI", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows Cancel Selected and Pause Selected buttons when at least one stream is selected", () => {
+    const streams = [
+      createMockStream("1", "active"),
+      createMockStream("2", "scheduled"),
+    ];
+
+    render(<StreamsTable {...defaultProps} streams={streams} />);
+
+    expect(screen.queryByText("Cancel Selected")).not.toBeInTheDocument();
+    expect(screen.queryByText("Pause Selected")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Select stream 1"));
+
+    expect(screen.getByText("Cancel Selected")).toBeInTheDocument();
+    expect(screen.getByText("Pause Selected")).toBeInTheDocument();
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+  });
+
+  it("hides bulk action buttons when all streams are deselected", () => {
+    render(<StreamsTable {...defaultProps} streams={[createMockStream("1", "active")]} />);
+
+    fireEvent.click(screen.getByLabelText("Select stream 1"));
+    expect(screen.getByText("Cancel Selected")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Select stream 1"));
+    expect(screen.queryByText("Cancel Selected")).not.toBeInTheDocument();
+  });
+
+  it("shows confirmation modal when Cancel Selected is clicked", () => {
+    const streams = [
+      createMockStream("1", "active"),
+      createMockStream("2", "active"),
+    ];
+
+    render(<StreamsTable {...defaultProps} streams={streams} />);
+
+    fireEvent.click(screen.getByLabelText("Select stream 1"));
+    fireEvent.click(screen.getByText("Cancel Selected"));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/will be canceled/i)).toBeInTheDocument();
+  });
+
+  it("calls onBulkCancel when confirmed in modal", async () => {
+    const onBulkCancel = vi.fn().mockResolvedValue(undefined);
+    const streams = [createMockStream("1", "active")];
+
+    render(
+      <StreamsTable
+        {...defaultProps}
+        streams={streams}
+        onBulkCancel={onBulkCancel}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Select stream 1"));
+    fireEvent.click(screen.getByText("Cancel Selected"));
+
+    const confirmBtns = screen.getAllByText("Cancel 1 Stream");
+    const confirmBtn = confirmBtns.find(
+      (btn) => btn.tagName === "BUTTON",
+    );
+    expect(confirmBtn).toBeDefined();
+    fireEvent.click(confirmBtn!);
+
+    await vi.waitFor(() => {
+      expect(onBulkCancel).toHaveBeenCalledWith(["1"]);
+    });
   });
 });

--- a/frontend/src/components/StreamsTable.tsx
+++ b/frontend/src/components/StreamsTable.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Stream } from "../types/stream";
-import { getExportCsvUrl, ListStreamsFilters, cancelStream } from "../services/api";
+import { getExportCsvUrl, ListStreamsFilters } from "../services/api";
 import { CopyableAddress } from "./CopyableAddress";
 import { StreamTimeline } from "./StreamTimeline";
 import { getHealthBadges } from "../utils/streamHealthBadges";
@@ -22,6 +22,7 @@ import {
   type OptionalStreamColumn,
 } from "../hooks/useStreamTableColumns";
 import { useWebSocket } from "../hooks/useWebSocket";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 interface StreamsTableProps {
   streams: Stream[];
@@ -31,6 +32,8 @@ interface StreamsTableProps {
   onCancel: (streamId: string) => Promise<void>;
   onPause: (streamId: string) => Promise<void>;
   onResume: (streamId: string) => Promise<void>;
+  onBulkCancel?: (streamIds: string[]) => Promise<void>;
+  onBulkPause?: (streamIds: string[]) => Promise<void>;
   onOpenStream?: (streamId: string) => void;
   onEditStartTime: (stream: Stream, triggerRef: RefObject<HTMLButtonElement | null>) => void;
   // Optional props expected by App.tsx
@@ -99,6 +102,8 @@ export function StreamsTable({
   onCancel,
   onPause,
   onResume,
+  onBulkCancel,
+  onBulkPause,
   onEditStartTime,
   onOpenStream,
   onLoadMore,
@@ -161,8 +166,8 @@ export function StreamsTable({
 
   const [selectedStreamIds, setSelectedStreamIds] = useState<Set<string>>(new Set());
   const [expandedStreamId, setExpandedStreamId] = useState<string | null>(null);
-  const [isBulkCanceling, setIsBulkCanceling] = useState(false);
-  const [bulkCancelProgress, setBulkCancelProgress] = useState({ current: 0, total: 0 });
+  const [pendingBulkAction, setPendingBulkAction] = useState<"cancel" | "pause" | null>(null);
+  const [isBulkProcessing, setIsBulkProcessing] = useState(false);
 
   const exportUrl = useMemo(() => getExportCsvUrl(filters as Record<string, string>), [filters]);
 
@@ -242,26 +247,23 @@ export function StreamsTable({
     onOpenStream?.(id);
   }, [onOpenStream]);
 
-  const handleBulkCancel = useCallback(async () => {
-    const idsToCancel = Array.from(selectedStreamIds);
-    if (idsToCancel.length === 0) return;
+  const handleBulkActionConfirm = useCallback(async () => {
+    const ids = Array.from(selectedStreamIds);
+    if (ids.length === 0) return;
 
-    setIsBulkCanceling(true);
-    setBulkCancelProgress({ current: 0, total: idsToCancel.length });
-
-    for (let i = 0; i < idsToCancel.length; i++) {
-      setBulkCancelProgress({ current: i + 1, total: idsToCancel.length });
-      try {
-        await cancelStream(idsToCancel[i]);
-      } catch (error) {
-        console.error(`Failed to cancel stream ${idsToCancel[i]}:`, error);
+    setIsBulkProcessing(true);
+    try {
+      if (pendingBulkAction === "cancel" && onBulkCancel) {
+        await onBulkCancel(ids);
+      } else if (pendingBulkAction === "pause" && onBulkPause) {
+        await onBulkPause(ids);
       }
+      setSelectedStreamIds(new Set());
+    } finally {
+      setIsBulkProcessing(false);
+      setPendingBulkAction(null);
     }
-
-    setSelectedStreamIds(new Set());
-    setIsBulkCanceling(false);
-    setBulkCancelProgress({ current: 0, total: 0 });
-  }, [selectedStreamIds]);
+  }, [selectedStreamIds, pendingBulkAction, onBulkCancel, onBulkPause]);
 
   useEffect(() => {
     setSelectedStreamIds((prev) => {
@@ -411,9 +413,36 @@ export function StreamsTable({
             alignItems: "center",
             marginBottom: "1rem",
             gap: "0.75rem",
+            flexWrap: "wrap",
           }}
         >
-          <h2 style={{ margin: 0 }}>Live Streams</h2>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+            <h2 style={{ margin: 0 }}>Live Streams</h2>
+            {selectedStreamIds.size > 0 && (
+              <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+                <span className="muted" style={{ fontSize: "0.85rem" }}>
+                  {selectedStreamIds.size} selected
+                </span>
+                <button
+                  type="button"
+                  className="btn-ghost"
+                  onClick={() => setPendingBulkAction("cancel")}
+                  disabled={isBulkProcessing}
+                  style={{ color: "var(--color-danger, #e53e3e)" }}
+                >
+                  Cancel Selected
+                </button>
+                <button
+                  type="button"
+                  className="btn-ghost"
+                  onClick={() => setPendingBulkAction("pause")}
+                  disabled={isBulkProcessing}
+                >
+                  Pause Selected
+                </button>
+              </div>
+            )}
+          </div>
           <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
             <div className="column-toggle" ref={columnsRef} style={{ position: "relative" }}>
               <button
@@ -563,46 +592,112 @@ export function StreamsTable({
         </div>
       </div>
 
-      {selectedStreamIds.size > 0 && (
-        <BulkActionBar
-          selectedCount={selectedStreamIds.size}
-          onCancel={handleBulkCancel}
-          isCanceling={isBulkCanceling}
-          progress={bulkCancelProgress}
+      {pendingBulkAction && (
+        <BulkConfirmModal
+          action={pendingBulkAction}
+          streamIds={Array.from(selectedStreamIds)}
+          streams={streamsWithProgress}
+          isProcessing={isBulkProcessing}
+          onConfirm={handleBulkActionConfirm}
+          onClose={() => {
+            if (!isBulkProcessing) setPendingBulkAction(null);
+          }}
         />
       )}
     </>
   );
 }
 
-interface BulkActionBarProps {
-  selectedCount: number;
-  onCancel: () => void;
-  isCanceling: boolean;
-  progress: { current: number; total: number };
+interface BulkConfirmModalProps {
+  action: "cancel" | "pause";
+  streamIds: string[];
+  streams: Stream[];
+  isProcessing: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
 }
 
-function BulkActionBar({
-  selectedCount,
-  onCancel,
-  isCanceling,
-  progress,
-}: BulkActionBarProps) {
+function BulkConfirmModal({
+  action,
+  streamIds,
+  streams,
+  isProcessing,
+  onConfirm,
+  onClose,
+}: BulkConfirmModalProps) {
+  const panelRef = useFocusTrap<HTMLDivElement>(true);
+  const actionLabel = action === "cancel" ? "Cancel" : "Pause";
+  const actionLabelPast = action === "cancel" ? "Canceled" : "Paused";
+
+  const selectedStreams = useMemo(
+    () => streams.filter((s) => streamIds.includes(s.id)),
+    [streams, streamIds],
+  );
+
   return (
-    <div className="bulk-action-bar">
-      <div className="bulk-action-bar__content">
-        <span className="bulk-action-bar__count">
-          {selectedCount} stream{selectedCount !== 1 ? "s" : ""} selected
-        </span>
-        <button
-          className="bulk-action-bar__button"
-          onClick={onCancel}
-          disabled={isCanceling}
+    <div
+      className="modal-backdrop"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !isProcessing) onClose();
+      }}
+    >
+      <div
+        ref={panelRef}
+        className="modal-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="bulk-confirm-title"
+      >
+        <h2 id="bulk-confirm-title">
+          {actionLabel} {streamIds.length} Stream{streamIds.length !== 1 ? "s" : ""}
+        </h2>
+
+        <p className="muted">
+          The following stream{streamIds.length !== 1 ? "s" : ""} will be {action === "cancel" ? "canceled" : "paused"}:
+        </p>
+
+        <ul
+          style={{
+            maxHeight: "200px",
+            overflowY: "auto",
+            margin: "0.5rem 0",
+            paddingLeft: "1.25rem",
+            fontSize: "0.85rem",
+          }}
         >
-          {isCanceling
-            ? `Canceling ${progress.current}/${progress.total}...`
-            : `Cancel ${selectedCount} Stream${selectedCount !== 1 ? "s" : ""}`}
-        </button>
+          {selectedStreams.map((s) => (
+            <li key={s.id}>
+              {s.id} — {s.recipient.slice(0, 8)}… ({s.assetCode})
+            </li>
+          ))}
+        </ul>
+
+        {isProcessing && (
+          <p className="muted" role="status" aria-live="polite">
+            {actionLabelPast}...
+          </p>
+        )}
+
+        <div className="modal-actions">
+          {isProcessing ? (
+            <button type="button" className="btn-primary" disabled aria-busy="true">
+              {actionLabelPast}…
+            </button>
+          ) : (
+            <>
+              <button type="button" className="btn-ghost" onClick={onClose}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={`btn-primary ${action === "cancel" ? "btn-danger" : ""}`}
+                onClick={onConfirm}
+              >
+                {actionLabel} {streamIds.length} Stream{streamIds.length !== 1 ? "s" : ""}
+              </button>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -317,6 +317,14 @@ input {
   cursor: not-allowed;
 }
 
+.btn-danger {
+  background: #c0392b;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: #a93226;
+}
+
 .btn-ghost {
   border: 1px solid #d1d5db;
   border-radius: 8px;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -360,6 +360,42 @@ export async function getConfig(): Promise<AppConfig> {
   return parseResponse<AppConfig>(response);
 }
 
+export interface BulkActionResult {
+  streamId: string;
+  success: boolean;
+  error?: string;
+}
+
+export async function bulkCancelStreams(streamIds: string[]): Promise<BulkActionResult[]> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (authToken) {
+    headers["Authorization"] = `Bearer ${authToken}`;
+  }
+
+  const response = await fetch(`${API_BASE}/streams/bulk-cancel`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ streamIds }),
+  });
+  const body = await parseResponse<{ results: BulkActionResult[] }>(response);
+  return body.results;
+}
+
+export async function bulkPauseStreams(streamIds: string[]): Promise<BulkActionResult[]> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (authToken) {
+    headers["Authorization"] = `Bearer ${authToken}`;
+  }
+
+  const response = await fetch(`${API_BASE}/streams/bulk-pause`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ streamIds }),
+  });
+  const body = await parseResponse<{ results: BulkActionResult[] }>(response);
+  return body.results;
+}
+
 export function clearCache() {
   cache.clear();
 }


### PR DESCRIPTION
## Summary

Implements bulk cancel and pause functionality for the StreamsTable component. Replaces the old floating `BulkActionBar` with toolbar-integrated action buttons and a confirmation modal, backed by new server-side bulk endpoints.

## Changes

### Backend (`backend/src/index.ts`)
- **`POST /api/streams/bulk-cancel`** — accepts `{ streamIds: string[] }`, validates each ID, checks sender auth, calls `cancelStream()` sequentially, returns per-stream `{ streamId, success, error? }` results
- **`POST /api/streams/bulk-pause`** — same pattern for `pauseStream()`

### Frontend API (`frontend/src/services/api.ts`)
- Added `BulkActionResult` interface
- Added `bulkCancelStreams(streamIds)` and `bulkPauseStreams(streamIds)` functions calling the new endpoints

### App.tsx
- Added `handleBulkCancel` and `handleBulkPause` handlers:
  - Call bulk API endpoints
  - Show success toast on full success
  - Show error toast with per-stream failure details on partial failure
  - Refresh stream list and unfiltered count after completion
- Passed `onBulkCancel` and `onBulkPause` props to `StreamsTable`

### StreamsTable (`frontend/src/components/StreamsTable.tsx`)
- **Removed**: Floating `BulkActionBar` component and its sequential individual-cancel loop
- **Added**: "Cancel Selected" and "Pause Selected" buttons in the table toolbar, visible when `selectedStreamIds.size > 0`, disabled during processing
- **Added**: `BulkConfirmModal` component with `useFocusTrap`, scrollable stream list, backdrop dismiss, and confirm button
- State: `pendingBulkAction` ("cancel" | "pause" | null) for modal, `isBulkProcessing` flag

### Styles (`frontend/src/index.css`)
- Added `.btn-danger` class (red background) for cancel confirmation button

### Tests (`frontend/src/components/StreamsTable.test.tsx`)
- **4 new tests**: button visibility on selection, button hide on deselect, modal display, onBulkCancel callback
- **Fixed**: Pre-existing `IntersectionObserver` mock (arrow function → proper constructor)

## Acceptance Criteria

- Toolbar-integrated "Cancel Selected" and "Pause Selected" buttons when >= 1 stream selected
- Confirmation modal listing selected streams (ID, recipient, asset)
- Calls POST /api/streams/bulk-cancel (or bulk-pause) with selected IDs
- Clears selection and refreshes list on success
- Toast errors show per-stream failure details
- 4 passing Vitest tests

# Closes #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk actions for selected streams, including cancel and pause.
  * Users now see a confirmation dialog with the selected streams before completing a bulk action.
  * Bulk results now show per-stream success or failure details, with clearer success and error toasts.

* **Bug Fixes**
  * Improved infinite scroll test reliability and selection flow behavior.
  * Added stronger handling for bulk action errors and loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->