### PR TITLE
fix: enforce minimum stream duration validation

### DIFF
--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -506,7 +506,7 @@ describe("POST /api/streams", () => {
     );
   });
 
-it("returns 400 when durationSeconds is zero", async () => {
+it("returns 400 when durationSeconds is below the 60-second minimum", async () => {
      const response = await request(app)
        .post("/api/streams")
        .set("Authorization", "Bearer mock_token")
@@ -515,12 +515,12 @@ it("returns 400 when durationSeconds is zero", async () => {
          recipient: RECIPIENT_1,
          assetCode: "USDC",
          totalAmount: 100,
-         durationSeconds: 0,
+         durationSeconds: 30,
        });
 
      expect(response.status).toBe(400);
      expect(response.body.code).toBe("VALIDATION_ERROR");
-     expect(response.body.error).toContain("durationSeconds must be at least 1 second");
+     expect(response.body.error).toContain("durationSeconds must be at least 60 seconds");
    });
 
   it("returns 400 when assetCode is not allowed", async () => {

--- a/backend/src/validation/schemas.test.ts
+++ b/backend/src/validation/schemas.test.ts
@@ -299,8 +299,13 @@ describe("Duration Seconds Schema", () => {
         expect(result.success).toBe(false);
     });
 
-    it("should accept 1 second as minimum valid duration", () => {
-        const result = durationSecondsSchema.safeParse(1);
+    it("should reject durations below 60 seconds", () => {
+        const result = durationSecondsSchema.safeParse(59);
+        expect(result.success).toBe(false);
+    });
+
+    it("should accept 60 seconds as minimum valid duration", () => {
+        const result = durationSecondsSchema.safeParse(60);
         expect(result.success).toBe(true);
     });
 

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -46,7 +46,7 @@ export const totalAmountSchema = z.coerce
 export const durationSecondsSchema = z.coerce
   .number()
   .int("durationSeconds must be a whole number of seconds.")
-  .min(1, "durationSeconds must be at least 1 second.");
+  .min(60, "durationSeconds must be at least 60 seconds.");
 
 export const unixTimestampSchema = z.coerce
   .number()


### PR DESCRIPTION

Closes #612 



- [x] I kept the change focused on the related issue.
- [x] I added or updated tests where useful.
- [x] I updated documentation where behavior changed.
- [x] I verified the app still builds or explained why verification was skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated duration validation so values under 60 seconds are now rejected.
  * Improved related error messaging to clearly state the 60-second minimum.
  * Aligned validation checks and test coverage with the new minimum duration rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->